### PR TITLE
mcp_host/goal_driven 보정 로직 재점검: ambiguous selector 전파 정합성 보완

### DIFF
--- a/gaia/src/phase4/goal_driven/agent.py
+++ b/gaia/src/phase4/goal_driven/agent.py
@@ -750,7 +750,7 @@ class GoalDrivenAgent:
         if success and changed:
             self._ineffective_ref_counts.pop(ref_id, None)
             return
-        if reason_code in {"no_state_change", "not_actionable", "ambiguous_ref_target"}:
+        if reason_code in {"no_state_change", "not_actionable", "ambiguous_ref_target", "ambiguous_selector"}:
             self._ineffective_ref_counts[ref_id] = int(self._ineffective_ref_counts.get(ref_id, 0)) + 1
 
     @staticmethod
@@ -858,7 +858,7 @@ class GoalDrivenAgent:
             if int(stat.get("hard_fail") or 0) > 0:
                 stat["hard_fail"] = int(stat["hard_fail"]) - 1
             return
-        if reason_code in {"no_state_change", "not_actionable", "blocked_ref_no_progress", "ambiguous_ref_target"}:
+        if reason_code in {"no_state_change", "not_actionable", "blocked_ref_no_progress", "ambiguous_ref_target", "ambiguous_selector"}:
             stat["soft_fail"] = min(200, int(stat.get("soft_fail") or 0) + 1)
         else:
             stat["hard_fail"] = min(200, int(stat.get("hard_fail") or 0) + 1)
@@ -2485,13 +2485,13 @@ class GoalDrivenAgent:
                     time.sleep(0.25)
                     continue
 
-                if self._no_progress_counter >= 2 and reason_code in {"no_state_change", "not_actionable", "ambiguous_ref_target", "blocked_ref_no_progress", "blocked_logout_action"} and decision.action in {
+                if self._no_progress_counter >= 2 and reason_code in {"no_state_change", "not_actionable", "ambiguous_ref_target", "ambiguous_selector", "blocked_ref_no_progress", "blocked_logout_action"} and decision.action in {
                     ActionType.CLICK,
                     ActionType.FILL,
                     ActionType.PRESS,
                 }:
                     force_context_shift = True
-                if reason_code in {"snapshot_not_found", "stale_snapshot", "ref_required", "ambiguous_ref_target", "not_found"}:
+                if reason_code in {"snapshot_not_found", "stale_snapshot", "ref_required", "ambiguous_ref_target", "ambiguous_selector", "not_found"}:
                     self._log("♻️ snapshot/ref 갱신이 필요해 DOM을 재수집합니다.")
                     _ = self._analyze_dom()
                     ineffective_action_streak = 0
@@ -3396,7 +3396,7 @@ JSON 응답:"""
 
             reason_code = str(data.get("reason_code") or data.get("error") or "unknown_error")
             reason = str(data.get("reason") or data.get("message") or data.get("detail") or "Unknown error")
-            if reason_code in {"snapshot_not_found", "stale_snapshot", "ambiguous_ref_target"}:
+            if reason_code in {"snapshot_not_found", "stale_snapshot", "ambiguous_ref_target", "ambiguous_selector"}:
                 reason = (
                     f"{reason} | 최신 snapshot/ref로 다시 시도해야 합니다."
                     if reason

--- a/gaia/src/phase4/mcp_host.py
+++ b/gaia/src/phase4/mcp_host.py
@@ -5084,13 +5084,14 @@ async def _browser_act(params: Dict[str, Any]) -> Dict[str, Any]:
     )
     ok = bool(legacy.get("success"))
     reason = str(legacy.get("message") or legacy.get("reason") or "")
-    reason_code = "ok" if ok else str(legacy.get("reason_code") or "failed")
+    reason_code = str(legacy.get("reason_code") or ("ok" if ok else "failed"))
+    effective = bool(legacy.get("effective", ok))
     return {
         "success": ok,
-        "effective": ok,
+        "effective": effective,
         "reason_code": reason_code,
         "reason": reason or ("ok" if ok else "action_failed"),
-        "state_change": {"effective": ok},
+        "state_change": {"effective": effective},
         "attempt_logs": [],
         "snapshot_id_used": snapshot_id,
         "ref_id_used": ref_id,

--- a/gaia/src/phase4/openclaw_protocol.py
+++ b/gaia/src/phase4/openclaw_protocol.py
@@ -83,6 +83,8 @@ REASON_CODES = {
     "request_exception",
     "tab_scope_mismatch",
     "frame_scope_mismatch",
+    "ambiguous_selector",
+    "ambiguous_ref_target",
     "http_4xx",
     "http_5xx",
 }


### PR DESCRIPTION
## 배경
origin/main HEAD 기준으로 OpenClaw 최신 동작을 재비교한 결과, `browser_act`의 legacy 경로에서 실패 사유(`reason_code`)와 `effective` 플래그 전파가 일부 단순화되어 goal_driven 복구 분기와 미세하게 어긋나는 지점이 있었습니다.

## 변경 사항
- `gaia/src/phase4/mcp_host.py`
  - `browser_act`의 legacy fallback 응답에서 `reason_code`/`effective`를 원본 실행 결과 기준으로 그대로 전파
  - `state_change.effective`도 동일 값으로 정합성 유지
- `gaia/src/phase4/goal_driven/agent.py`
  - `ambiguous_selector`를 `ambiguous_ref_target`와 동일한 보정/복구 신호로 취급
  - no-progress 컨텍스트 전환, snapshot 재수집 트리거, 사용자 피드백 문구 분기에 반영
- `gaia/src/phase4/openclaw_protocol.py`
  - 프로토콜 reason code 집합에 `ambiguous_selector`, `ambiguous_ref_target` 명시

## 검증
- `python3 -m py_compile gaia/src/phase4/mcp_host.py gaia/src/phase4/openclaw_protocol.py gaia/src/phase4/goal_driven/agent.py`

## 범위
- 기준: `origin/main`
- 기존 `fix/mcp-host-strict-locator` 브랜치 cherry-pick 없이, 필요한 부분만 최소 침습 반영
