### PR TITLE
Add benchmark scenario suites for public sites(벤치마크 사이트 + 시나리오  추가)

### DIFF
--- a/gaia/src/benchmark_manager.py
+++ b/gaia/src/benchmark_manager.py
@@ -164,6 +164,13 @@ BENCHMARK_PRESETS: tuple[BenchmarkPreset, ...] = (
         host_aliases=("musinsa.com", "www.musinsa.com"),
     ),
     BenchmarkPreset(
+        key="bunjang",
+        label="Bunjang",
+        default_url="https://m.bunjang.co.kr/",
+        suite_path="gaia/tests/scenarios/bunjang_public_suite.json",
+        host_aliases=("bunjang.co.kr", "m.bunjang.co.kr", "www.bunjang.co.kr"),
+    ),
+    BenchmarkPreset(
         key="yes24",
         label="YES24",
         default_url="https://www.yes24.com/",
@@ -239,6 +246,27 @@ BENCHMARK_PRESETS: tuple[BenchmarkPreset, ...] = (
         default_url="https://culture.seoul.go.kr/",
         suite_path="gaia/tests/scenarios/seoul_culture_public_suite.json",
         host_aliases=("culture.seoul.go.kr",),
+    ),
+    BenchmarkPreset(
+        key="grafana",
+        label="Grafana",
+        default_url="http://15.164.24.65:3000/?orgId=1&from=now-6h&to=now&timezone=browser",
+        suite_path="gaia/tests/scenarios/grafana_public_suite.json",
+        host_aliases=("15.164.24.65:3000", "15.164.24.65"),
+    ),
+    BenchmarkPreset(
+        key="namu_wiki",
+        label="나무위키",
+        default_url="https://namu.wiki/",
+        suite_path="gaia/tests/scenarios/namu_wiki_public_suite.json",
+        host_aliases=("namu.wiki", "www.namu.wiki"),
+    ),
+    BenchmarkPreset(
+        key="lotteworld_adventure",
+        label="롯데월드 어드벤처",
+        default_url="https://adventure.lotteworld.com/",
+        suite_path="gaia/tests/scenarios/lotteworld_adventure_public_suite.json",
+        host_aliases=("adventure.lotteworld.com", "lotteworld.com"),
     ),
 )
 
@@ -667,6 +695,8 @@ def _remap_suite_url(original_url: str, old_base_url: str, target_url: str) -> s
     target = str(target_url or "").strip()
     if not source or not target:
         return source or target
+    if source.rstrip("/") == target.rstrip("/"):
+        return target
     if not old_base:
         return target
     normalized_base = old_base.rstrip("/")

--- a/gaia/tests/scenarios/apple_store_public_suite.json
+++ b/gaia/tests/scenarios/apple_store_public_suite.json
@@ -77,6 +77,25 @@
       },
       "expected_signals": [],
       "time_budget_sec": 600
+    },
+    {
+      "id": "APPLE_006_IPAD_PENCIL_FEATURES_MODEL",
+      "name": "iPad Apple Pencil 특징 모델 선택 확인",
+      "url": "https://www.apple.com/kr/",
+      "goal": "Apple Korea 홈에서 iPad를 선택한 후 Apple Pencil 페이지로 이동한다. 이후 'Apple Pencil 특징 모두 보기'를 클릭하고 스크롤을 내려 iPad 모델이 iPad Pro 11로 선택되는지 확인해줘.",
+      "constraints": {
+        "allow_navigation": true,
+        "require_ref_only": true,
+        "require_state_change": false
+      },
+      "expected_signals": [
+        "iPad",
+        "Apple Pencil",
+        "특징 모두 보기",
+        "iPad Pro 11",
+        "모델"
+      ],
+      "time_budget_sec": 600
     }
   ]
 }

--- a/gaia/tests/scenarios/custom_chat_gpt_suite.json
+++ b/gaia/tests/scenarios/custom_chat_gpt_suite.json
@@ -1,0 +1,24 @@
+{
+  "suite_id": "chat_gpt_public_v1",
+  "site": {
+    "name": "Chat gpt",
+    "base_url": "https://chatgpt.com/",
+    "mode": "public_browse"
+  },
+  "grader_configs": {},
+  "scenarios": [
+    {
+      "id": "CHATGPT_001_GAIA_VS_HUMAN_V1",
+      "name": "Gaia_VS_Human_V1",
+      "url": "https://chatgpt.com/",
+      "goal": "새 채팅 생성 후 “자동화 QA의 이점 한가지만 알려줘”라고 입력했을 때 답변 영역이 정상 렌더링되는지 확인해줘.",
+      "constraints": {
+        "allow_navigation": true,
+        "require_ref_only": true,
+        "require_state_change": false
+      },
+      "time_budget_sec": 300,
+      "expected_signals": []
+    }
+  ]
+}

--- a/gaia/tests/scenarios/custom_ikea_kr_suite.json
+++ b/gaia/tests/scenarios/custom_ikea_kr_suite.json
@@ -1,0 +1,31 @@
+{
+  "suite_id": "ikea_kr_public_v1",
+  "site": {
+    "name": "이케아",
+    "base_url": "https://www.ikea.com/kr/ko/",
+    "mode": "public_browse"
+  },
+  "grader_configs": {},
+  "scenarios": [
+    {
+      "id": "IKEA_001_GAIA_VS_HUMAN_V1",
+      "name": "Gaia_VS_Human_V1",
+      "url": "https://www.ikea.com/kr/ko/",
+        "goal": "이케아 홈에서 수납용품 영역을 통해 분리수거함 상품 목록으로 이동한다. 이후 반드시 \"베스트셀러\" 필터를 클릭해 필터가 적용된 상태로 만들고, 적용된 상품 목록에서 \"홀바르 휴지통\" 상품만 표시되는지 확인해줘. 필터를 클릭하기 전부터 홀바르 휴지통이 보이는 것만으로는 성공 처리하지 마.",
+      "constraints": {
+        "allow_navigation": true,
+        "require_ref_only": true,
+        "require_state_change": false
+      },
+      "time_budget_sec": 300,
+      "expected_signals": [
+        "수납용품",
+        "분리수거함",
+        "베스트셀러",
+        "필터",
+        "홀바르",
+        "휴지통"
+      ]
+    }
+  ]
+}

--- a/gaia/tests/scenarios/external_public_manifest.json
+++ b/gaia/tests/scenarios/external_public_manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_id": "external_public_korea_focused_v2",
   "name": "Korea-focused external public benchmark",
-  "site_count": 30,
-  "scenario_count": 150,
-  "selection_note": "30 external public sites, mostly Korea-facing services familiar to the presentation audience. CAPTCHA-heavy or bot-wall-prone sites are excluded from the primary curated pack.",
+  "site_count": 32,
+  "scenario_count": 152,
+  "selection_note": "32 external public sites, mostly Korea-facing services familiar to the presentation audience. CAPTCHA-heavy or bot-wall-prone sites are excluded from the primary curated pack.",
   "suites": [
     {
       "site_key": "wikipedia",
@@ -244,6 +244,22 @@
       "volatility": "medium",
       "base_url": "https://culture.seoul.go.kr/",
       "suite_path": "gaia/tests/scenarios/seoul_culture_public_suite.json"
+    },
+    {
+      "site_key": "namu_wiki",
+      "label": "나무위키",
+      "category": "knowledge_reference",
+      "volatility": "high",
+      "base_url": "https://namu.wiki/",
+      "suite_path": "gaia/tests/scenarios/namu_wiki_public_suite.json"
+    },
+    {
+      "site_key": "lotteworld_adventure",
+      "label": "롯데월드 어드벤처",
+      "category": "culture_public",
+      "volatility": "medium",
+      "base_url": "https://adventure.lotteworld.com/",
+      "suite_path": "gaia/tests/scenarios/lotteworld_adventure_public_suite.json"
     }
   ]
 }

--- a/gaia/tests/scenarios/grafana_public_suite.json
+++ b/gaia/tests/scenarios/grafana_public_suite.json
@@ -1,0 +1,36 @@
+{
+  "suite_id": "grafana_public_v1",
+  "site": {
+    "name": "Grafana",
+    "base_url": "http://15.164.24.65:3000/?orgId=1&from=now-6h&to=now&timezone=browser",
+    "mode": "public_browse"
+  },
+  "grader_configs": {
+    "reason_codes": {
+      "forbidden_reason_codes": [
+        "user_intervention_missing"
+      ]
+    }
+  },
+  "scenarios": [
+    {
+      "id": "GRAFANA_001_LOGIN_AND_BENCHMARK_DASHBOARD",
+      "name": "admin 로그인 후 GAIA Benchmark Result 확인",
+      "url": "http://15.164.24.65:3000/?orgId=1&from=now-6h&to=now&timezone=browser",
+      "goal": "Grafana에서 id는 admin, 비밀번호는 changeme를 입력해 로그인한 뒤 Dashboards를 클릭하고 GAIA Benchmark Result 대시보드를 열어, 시나리오 성공률과 설명 정보가 화면에 나타나는지 확인해줘.",
+      "constraints": {
+        "allow_navigation": true,
+        "require_ref_only": true,
+        "require_state_change": true
+      },
+      "expected_signals": [
+        "admin",
+        "Dashboards",
+        "GAIA Benchmark Result",
+        "성공률",
+        "설명"
+      ],
+      "time_budget_sec": 600
+    }
+  ]
+}

--- a/gaia/tests/scenarios/jobkorea_public_suite.json
+++ b/gaia/tests/scenarios/jobkorea_public_suite.json
@@ -77,6 +77,26 @@
       },
       "expected_signals": [],
       "time_budget_sec": 600
+    },
+    {
+      "id": "JOBKOREA_006_ONEPICK_HIGH_SALARY_FILTER",
+      "name": "합격축하금 통큰 연봉 필터 확인",
+      "url": "https://www.jobkorea.co.kr/",
+      "goal": "잡코리아에서 합격축하금 채용공고 페이지로 이동한 후 \"통큰 연봉\" 필터를 적용한다. 이후 채용공고 리스트에서 기업명과 연봉 정보가 정상적으로 표시되는지 확인해줘.",
+      "constraints": {
+        "allow_navigation": true,
+        "require_ref_only": true,
+        "require_state_change": false
+      },
+      "expected_signals": [
+        "합격축하금",
+        "통큰 연봉",
+        "채용공고",
+        "기업명",
+        "연봉",
+        "만원"
+      ],
+      "time_budget_sec": 600
     }
   ]
 }

--- a/gaia/tests/scenarios/kakao_map_public_suite.json
+++ b/gaia/tests/scenarios/kakao_map_public_suite.json
@@ -77,6 +77,25 @@
       },
       "expected_signals": [],
       "time_budget_sec": 600
+    },
+    {
+      "id": "KAKAOMAP_006_INU_TRANSIT_ROUTE_TIME",
+      "name": "인천대학교 송도캠퍼스 2008년 스카이뷰 확인",
+      "url": "https://map.kakao.com/",
+      "goal": "카카오맵 검색창에 \"인천대학교 송도캠퍼스\"를 입력해 검색 결과를 선택한다. 이후 지도를 스카이뷰로 바꾸고 년도를 2008년으로 설정했을 때 지도가 스카이뷰로 정상 표시되는지 확인해줘.",
+      "constraints": {
+        "allow_navigation": true,
+        "require_ref_only": true,
+        "require_state_change": false
+      },
+      "expected_signals": [
+        "인천대학교 송도캠퍼스",
+        "스카이뷰",
+        "2008년",
+        "지도",
+        "항공사진"
+      ],
+      "time_budget_sec": 600
     }
   ]
 }

--- a/gaia/tests/scenarios/lotteworld_adventure_public_suite.json
+++ b/gaia/tests/scenarios/lotteworld_adventure_public_suite.json
@@ -1,0 +1,37 @@
+{
+  "suite_id": "lotteworld_adventure_public_v1",
+  "site": {
+    "name": "롯데월드 어드벤처",
+    "base_url": "https://adventure.lotteworld.com/",
+    "mode": "public_readonly"
+  },
+  "grader_configs": {
+    "reason_codes": {
+      "forbidden_reason_codes": [
+        "user_intervention_missing"
+      ]
+    }
+  },
+  "scenarios": [
+    {
+      "id": "LOTTEWORLD_001_MAGICPASS_ATTRACTION_LIST",
+      "name": "매직패스 권종별 탑승 가능 어트랙션 확인",
+      "url": "https://adventure.lotteworld.com/",
+      "goal": "홈에서 요금/혜택 부분을 클릭한 후 티켓요금을 클릭한다. 이후 매직패스를 클릭해서 어트랙션 보러가기를 눌렀을 때 권종별 탑승 가능 어트랙션이 나오는지 확인해줘.",
+      "constraints": {
+        "allow_navigation": true,
+        "require_ref_only": true,
+        "require_state_change": true
+      },
+      "expected_signals": [
+        "요금/혜택",
+        "티켓요금",
+        "매직패스",
+        "어트랙션 보러가기",
+        "권종별",
+        "탑승 가능 어트랙션"
+      ],
+      "time_budget_sec": 600
+    }
+  ]
+}

--- a/gaia/tests/scenarios/mbc_news_public_suite.json
+++ b/gaia/tests/scenarios/mbc_news_public_suite.json
@@ -77,6 +77,26 @@
       },
       "expected_signals": [],
       "time_budget_sec": 600
+    },
+    {
+      "id": "MBCNEWS_006_RESERVE_FORCE_SEARCH_ACCURACY",
+      "name": "예비군 검색 정확도순 결과 확인",
+      "url": "https://imnews.imbc.com/pc_main.html",
+      "goal": "MBC 뉴스 홈 화면에서 검색창에 \"예비군\"을 입력하여 검색을 수행한다. 이후 검색 결과 페이지에서 정렬 기준을 \"정확도순\"으로 변경했을 때 검색 결과 리스트가 정상적으로 갱신되고, 기사 제목 및 썸네일이 정상 표시되는지 확인해줘.",
+      "constraints": {
+        "allow_navigation": true,
+        "require_ref_only": true,
+        "require_state_change": false
+      },
+      "expected_signals": [
+        "예비군",
+        "정확도순",
+        "검색 결과",
+        "기사",
+        "제목",
+        "썸네일"
+      ],
+      "time_budget_sec": 600
     }
   ]
 }

--- a/gaia/tests/scenarios/melon_public_suite.json
+++ b/gaia/tests/scenarios/melon_public_suite.json
@@ -77,6 +77,25 @@
       },
       "expected_signals": [],
       "time_budget_sec": 600
+    },
+    {
+      "id": "MELON_006_IU_FLOWER_BOOKMARK_THREE_TRACK",
+      "name": "아이유 꽃갈피 셋 앨범 수록곡 확인",
+      "url": "https://www.melon.com/",
+      "goal": "멜론에서 \"꽃갈피 셋\"을 검색하고, 검색 결과에서 아티스트가 아이유인 앨범 상세 페이지로 이동한다. 이후 수록곡 목록에 \"Never Ending Story\"가 포함되어 있는지 확인해줘.",
+      "constraints": {
+        "allow_navigation": true,
+        "require_ref_only": true,
+        "require_state_change": false
+      },
+      "expected_signals": [
+        "꽃갈피 셋",
+        "아이유",
+        "앨범",
+        "수록곡",
+        "Never Ending Story"
+      ],
+      "time_budget_sec": 600
     }
   ]
 }

--- a/gaia/tests/scenarios/namu_wiki_public_suite.json
+++ b/gaia/tests/scenarios/namu_wiki_public_suite.json
@@ -1,0 +1,35 @@
+{
+  "suite_id": "namu_wiki_public_v1",
+  "site": {
+    "name": "나무위키",
+    "base_url": "https://namu.wiki/",
+    "mode": "public_readonly"
+  },
+  "grader_configs": {
+    "reason_codes": {
+      "forbidden_reason_codes": [
+        "user_intervention_missing"
+      ]
+    }
+  },
+  "scenarios": [
+    {
+      "id": "NAMU_001_REALTIME_TOP5_ARTICLE_STRUCTURE",
+      "name": "실시간 검색어 5위 문서 구조 확인",
+      "url": "https://namu.wiki/",
+      "goal": "나무위키 홈에서 실시간 검색어 목록의 5위 문서를 클릭한 뒤, 열린 문서 화면에서 분류와 목차가 잘 나타나는지 확인해줘.",
+      "constraints": {
+        "allow_navigation": true,
+        "require_ref_only": true,
+        "require_state_change": true
+      },
+      "expected_signals": [
+        "실시간 검색어",
+        "5위",
+        "분류",
+        "목차"
+      ],
+      "time_budget_sec": 600
+    }
+  ]
+}

--- a/gaia/tests/scenarios/naver_news_public_suite.json
+++ b/gaia/tests/scenarios/naver_news_public_suite.json
@@ -77,6 +77,27 @@
       },
       "expected_signals": [],
       "time_budget_sec": 600
+    },
+    {
+      "id": "NAVERNEWS_006_GAIA_HUMAN_V1",
+      "name": "\uc2a4\ud3ec\uce20 \ucd95\uad6c \uc21c\uc704\ud45c \uc0c1\uc704 3\ud300 \ud655\uc778",
+      "url": "https://news.naver.com/",
+      "goal": "\ud648 \ud654\uba74\uc5d0\uc11c \uc2a4\ud3ec\uce20 \ud544\ud130\ub97c \uc120\ud0dd\ud55c \ud6c4 \ucd95\uad6c \uce74\ud14c\uace0\ub9ac\ub85c \uc774\ub3d9\ud55c\ub2e4. \uc774\ud6c4 \uc21c\uc704 \ud544\ud130\ub97c \ud074\ub9ad\ud558\uc5ec \uc21c\uc704\ud45c \uc601\uc5ed\uc73c\ub85c \uc774\ub3d9\ud558\uace0, \uc0c1\uc704 3\uac1c \ud300\uc758 \uc21c\uc704 \uc815\ubcf4\uac00 \uc815\uc0c1\uc801\uc73c\ub85c \ud45c\uc2dc\ub418\ub294\uc9c0 \ud655\uc778\ud55c\ub2e4.",
+      "constraints": {
+        "allow_navigation": true,
+        "require_ref_only": true,
+        "require_state_change": false
+      },
+      "expected_signals": [
+        "\uc2a4\ud3ec\uce20",
+        "\ucd95\uad6c",
+        "\uc21c\uc704",
+        "\uc21c\uc704\ud45c",
+        "1",
+        "2",
+        "3"
+      ],
+      "time_budget_sec": 600
     }
   ]
 }

--- a/gaia/tests/scenarios/wikipedia_public_suite.json
+++ b/gaia/tests/scenarios/wikipedia_public_suite.json
@@ -77,6 +77,24 @@
       },
       "expected_signals": [],
       "time_budget_sec": 600
+    },
+    {
+      "id": "WIKI_006_GAIA_HUMAN_TEST_V1",
+      "name": "사용자 모임 경유 K-pop 포털 정보 확인",
+      "url": "https://ko.wikipedia.org/wiki/위키백과:대문",
+      "goal": "위키백과에서 사용자 모임을 클릭한 뒤, 포털 영역에서 K-pop을 선택했을 때 오늘의 아티스트나 오늘의 그림 같은 정보가 화면에 나타나는지 확인해줘.",
+      "constraints": {
+        "allow_navigation": true,
+        "require_ref_only": true,
+        "require_state_change": true
+      },
+      "expected_signals": [
+        "사용자 모임",
+        "K-pop",
+        "오늘의 아티스트",
+        "오늘의 그림"
+      ],
+      "time_budget_sec": 600
     }
   ]
 }

--- a/gaia/tests/scenarios/yes24_public_suite.json
+++ b/gaia/tests/scenarios/yes24_public_suite.json
@@ -77,6 +77,25 @@
       },
       "expected_signals": [],
       "time_budget_sec": 600
+    },
+    {
+      "id": "YES24_006_PROJECT_HAIL_MARY_SIZE_COMPARE",
+      "name": "프로젝트 헤일메리 사이즈 비교 확인",
+      "url": "https://www.yes24.com/Product/Search?query=%ED%94%84%EB%A1%9C%EC%A0%9D%ED%8A%B8%20%ED%97%A4%EC%9D%BC%EB%A9%94%EB%A6%AC",
+      "goal": "YES24에서 프로젝트 헤일메리 도서 검색 결과를 열고 첫 번째 상품을 클릭한다. 이후 상세 화면에서 사이즈비교 버튼을 클릭했을 때 도서의 가로와 세로 사이즈 정보가 정상적으로 표시되는지 확인해줘.",
+      "constraints": {
+        "allow_navigation": true,
+        "require_ref_only": true,
+        "require_state_change": false
+      },
+      "expected_signals": [
+        "프로젝트 헤일메리",
+        "사이즈비교",
+        "가로",
+        "세로",
+        "mm"
+      ],
+      "time_budget_sec": 600
     }
   ]
 }

--- a/gaia/tests/scenarios/youtube_public_suite.json
+++ b/gaia/tests/scenarios/youtube_public_suite.json
@@ -77,6 +77,44 @@
       },
       "expected_signals": [],
       "time_budget_sec": 600
+    },
+    {
+      "id": "YOUTUBE_006_GAIA_HUMAN_TEST_V1",
+      "name": "인천대 임베디드시스템 홍보영상 검색 결과 확인",
+      "url": "https://www.youtube.com/results?search_query=%EC%9D%B8%EC%B2%9C%EB%8C%80%20%EC%9E%84%EB%B2%A0%EB%94%94%EB%93%9C%EC%8B%9C%EC%8A%A4%ED%85%9C%20%ED%99%8D%EB%B3%B4%EC%98%81%EC%83%81",
+      "goal": "유튜브에서 인천대 임베디드시스템 홍보영상 검색 결과 화면을 열고, 영상 제목 목록과 채널명, 썸네일이 모두 표시되는지 확인해줘.",
+      "constraints": {
+        "allow_navigation": true,
+        "require_ref_only": true,
+        "require_state_change": false
+      },
+      "expected_signals": [
+        "인천대",
+        "임베디드시스템",
+        "홍보영상",
+        "영상",
+        "채널",
+        "썸네일"
+      ],
+      "time_budget_sec": 600
+    },
+    {
+      "id": "YOUTUBE_007_GAIA_HUMAN_TEST_V1_2",
+      "name": "Short test 확인",
+      "url": "https://www.youtube.com/",
+      "goal": "Shorts 탭으로 이동한 뒤 현재 제목/채널명을 확인하고, 다음 동영상으로 한번만 넘겨줘. 이후 제목과 채널명이 정상적으로 이전과 달라졌는지 확인해줘",
+      "constraints": {
+        "allow_navigation": true,
+        "require_ref_only": true,
+        "require_state_change": true
+      },
+      "expected_signals": [
+        "Shorts",
+        "채널명",
+        "제목",
+        "변경"
+      ],
+      "time_budget_sec": 600
     }
   ]
 }


### PR DESCRIPTION
## Summary
이번 PR은 benchmark용 시나리오 정의만 추가/수정한 변경입니다.
실행 결과 artifact나 임시 산출물은 포함하지 않았고, 사이트 등록 및 suite JSON만 정리했습니다.

## Updated Existing Site Scenarios

### Apple Store
- 시나리오 추가/수정
- 내용:
  - 홈에서 `iPad` 선택
  - `Apple Pencil` 선택
  - `Apple Pencil 특징 모두 보기` 클릭
  - 스크롤 후 iPad 모델이 `iPad Pro 11`로 선택되는지 확인

### Naver News
- 시나리오 추가/수정
- 내용:
  - 홈에서 `스포츠` 필터 선택
  - `축구` 카테고리 이동
  - `순위` 필터 클릭
  - 순위표 영역에서 상위 3개 팀의 순위 정보가 정상 표시되는지 확인

### YouTube
- 시나리오 추가/수정
- 내용 1:
  - `인천대 임베디드시스템 홍보영상` 검색 결과 화면 진입
  - 영상 제목 목록, 채널명, 썸네일 표시 여부 확인
- 내용 2:
  - `Shorts` 탭 이동
  - 현재 제목/채널명 확인
  - 다음 동영상으로 한 번만 넘긴 뒤
  - 제목과 채널명이 이전과 달라졌는지 확인

### YES24
- 시나리오 추가/수정
- 내용:
  - `프로젝트 헤일메리` 검색
  - 첫 번째 상품 클릭
  - `사이즈비교` 버튼 클릭
  - 가로/세로 사이즈 정보가 정상 표시되는지 확인

### Melon
- 시나리오 추가/수정
- 내용:
  - `꽃갈피 셋` 검색
  - 아티스트가 `아이유`인 앨범 상세 페이지 이동
  - 수록곡 목록에 `Never Ending Story` 포함 여부 확인

### JobKorea
- 시나리오 추가/수정
- 내용:
  - `합격축하금 채용공고` 페이지 이동
  - `통큰 연봉` 필터 적용
  - 채용공고 리스트에서 기업명과 연봉 정보가 정상 표시되는지 확인

### KakaoMap
- 시나리오 추가/수정
- 내용:
  - `인천대학교 송도캠퍼스` 검색
  - 검색 결과 선택
  - 지도를 `스카이뷰`로 전환
  - 연도를 `2008년`으로 설정
  - 스카이뷰가 정상 표시되는지 확인

### MBC News
- 시나리오 추가/수정
- 내용:
  - 검색창에 `예비군` 입력 후 검색
  - 검색 결과 페이지에서 정렬 기준을 `정확도순`으로 변경
  - 기사 제목과 썸네일이 정상 표시되는지 확인

## New Site Suites

### Grafana
- 신규 benchmark 사이트 추가
- 시나리오:
  - `admin / changeme` 로그인
  - `Dashboards` 클릭
  - `GAIA Benchmark Result` 대시보드 이동
  - 시나리오 성공률과 설명 정보가 화면에 표시되는지 확인

### 나무위키
- 신규 benchmark 사이트 추가
- 시나리오:
  - 홈의 실시간 검색어에서 5위 문서 클릭
  - 해당 문서에서 `분류`와 `목차`가 정상 표시되는지 확인

### 롯데월드 어드벤처
- 신규 benchmark 사이트 추가
- 시나리오:
  - 홈에서 `요금/혜택` 클릭
  - `티켓요금` 클릭
  - `매직패스` 클릭
  - `어트랙션 보러가기` 클릭
  - `권종별 탑승 가능 어트랙션`이 표시되는지 확인

## Additional Scenario Suite Additions
### Wikipedia
- 시나리오 추가/수정
- 내용:
  - `사용자 모임` 클릭
  - 포털 영역에서 `K-pop` 클릭
  - `오늘의 아티스트`, `오늘의 그림` 같은 정보가 화면에 나타나는지 확인

### Custom ChatGPT Suite
- 커스텀 benchmark suite 추가
- 시나리오:
  - 새 채팅 생성
  - `자동화 QA의 이점 한가지만 알려줘` 입력
  - 답변 영역이 정상 렌더링되는지 확인

### Custom IKEA KR Suite
- 커스텀 benchmark suite 추가
- 시나리오:
  - 홈에서 `수납용품` 필터 클릭
  - `분리수거함` 진입
  - `베스트 셀러` 클릭
  - 베스트셀러 상품들만 표시되는지 확인

## Registry / Catalog Updates
- `benchmark_manager.py`에 신규 사이트 preset 추가
- `external_public_manifest.json`에 신규 사이트 반영
- 각 사이트 suite JSON에 시나리오 추가 또는 갱신

## Scope
이 PR에는 아래만 포함됩니다.
- benchmark site 등록 정보
- scenario/suite definition JSON
- external public manifest 갱신

이 PR에는 아래를 포함하지 않습니다.
- 실행 결과 artifact
- benchmark 결과 리포트
- 임시 산출물