### PR TITLE
[codex] Add adaptive QA expansion mode

### DIFF
--- a/gaia/cli.py
+++ b/gaia/cli.py
@@ -15,7 +15,7 @@ import urllib.error
 import urllib.parse
 import urllib.request
 from pathlib import Path
-from typing import Sequence
+from typing import Callable, Sequence
 
 from gaia import auth as gaia_auth
 from gaia.src.phase4.session import (
@@ -36,7 +36,37 @@ else:
 PROFILE_PATH = Path.home() / ".gaia" / "cli_profile.json"
 AUTH_CHOICES = ("reuse", "fresh")
 RUNTIME_CHOICES = ("gui", "terminal")
-MODE_CHOICES = ("chat", "ai", "plan")
+ADAPTIVE_QA_MODE = "adaptive_qa"
+DEEP_ADAPTIVE_QA_MODE = "deep_adaptive_qa"
+MODE_CHOICES = ("chat", "ai", "plan", ADAPTIVE_QA_MODE, DEEP_ADAPTIVE_QA_MODE)
+QA_MODE_CHOICES = (
+    "off",
+    "adaptive",
+    "deep",
+    ADAPTIVE_QA_MODE,
+    "deep_qa",
+    DEEP_ADAPTIVE_QA_MODE,
+)
+QUICK_SPECIFIC_LABEL = "특정 기능 테스트"
+QUICK_ADAPTIVE_QA_LABEL = "QA 확장 테스트"
+QUICK_DEEP_QA_LABEL = "Deep QA 확장 테스트"
+QUICK_AUTONOMOUS_LABEL = "완전 자율"
+QUICK_RUN_MODE_CHOICES = (
+    QUICK_SPECIFIC_LABEL,
+    QUICK_ADAPTIVE_QA_LABEL,
+    QUICK_DEEP_QA_LABEL,
+    QUICK_AUTONOMOUS_LABEL,
+)
+QUICK_QA_MODE_BY_LABEL = {
+    QUICK_ADAPTIVE_QA_LABEL: ADAPTIVE_QA_MODE,
+    QUICK_DEEP_QA_LABEL: DEEP_ADAPTIVE_QA_MODE,
+}
+QUICK_PROFILE_KEY_BY_LABEL = {
+    QUICK_SPECIFIC_LABEL: "specific",
+    QUICK_ADAPTIVE_QA_LABEL: ADAPTIVE_QA_MODE,
+    QUICK_DEEP_QA_LABEL: DEEP_ADAPTIVE_QA_MODE,
+    QUICK_AUTONOMOUS_LABEL: "autonomous",
+}
 OPENAI_AUTH_METHOD_CHOICES = ("oauth", "manual")
 CONTROL_CHOICES = ("local", "telegram")
 TELEGRAM_MODE_CHOICES = ("polling", "webhook")
@@ -645,6 +675,40 @@ def _provider_model_priority(provider: str) -> Sequence[str]:
     return OLLAMA_MODEL_PRIORITY
 
 
+def _normalize_qa_mode(value: str | None) -> str | None:
+    raw = str(value or "").strip().lower()
+    if raw in {"", "off", "none", "default", "false", "0"}:
+        return None
+    if raw in {"adaptive", ADAPTIVE_QA_MODE, "progressive_qa"}:
+        return ADAPTIVE_QA_MODE
+    if raw in {"deep", "deep_qa", "aggressive_qa", DEEP_ADAPTIVE_QA_MODE}:
+        return DEEP_ADAPTIVE_QA_MODE
+    return None
+
+
+def _run_with_qa_mode_env(qa_mode: str | None, runner: Callable[[], int]) -> int:
+    normalized = _normalize_qa_mode(qa_mode)
+    if not normalized:
+        return runner()
+
+    keys = ("GAIA_ADAPTIVE_QA", "GAIA_DEEP_ADAPTIVE_QA")
+    previous = {key: os.environ.get(key) for key in keys}
+    try:
+        if normalized == DEEP_ADAPTIVE_QA_MODE:
+            os.environ.pop("GAIA_ADAPTIVE_QA", None)
+            os.environ["GAIA_DEEP_ADAPTIVE_QA"] = "1"
+        else:
+            os.environ["GAIA_ADAPTIVE_QA"] = "1"
+            os.environ.pop("GAIA_DEEP_ADAPTIVE_QA", None)
+        return runner()
+    finally:
+        for key, value in previous.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+
 def _resolve_runtime(parsed: argparse.Namespace, profile: dict[str, str], default: str = "gui") -> str:
     runtime = parsed.runtime or profile.get("last_runtime", default)
     if getattr(parsed, "gui", False):
@@ -1048,7 +1112,10 @@ def run_gui(argv: Sequence[str] | None = None) -> int:
     parser.add_argument("--plan")
     parser.add_argument("--bundle")
     parser.add_argument("--spec")
-    parser.add_argument("--mode", choices=("plan", "ai", "chat"))
+    parser.add_argument(
+        "--mode",
+        choices=("plan", "ai", "chat", ADAPTIVE_QA_MODE, DEEP_ADAPTIVE_QA_MODE),
+    )
     parser.add_argument("--control", choices=CONTROL_CHOICES)
     parser.add_argument("--feature-query")
     parser.add_argument("--max-actions", type=int)
@@ -1098,20 +1165,25 @@ def _dispatch_chat(
     repl: bool,
     *,
     session_id: str,
+    qa_mode: str | None = None,
 ) -> int:
+    normalized_qa_mode = _normalize_qa_mode(qa_mode)
     if runtime == "gui":
-        forwarded = ["--mode", "chat", "--url", url]
+        forwarded = ["--mode", normalized_qa_mode or "chat", "--url", url]
         if feature_query:
             forwarded += ["--feature-query", feature_query]
         return run_gui(forwarded)
 
     from gaia.terminal import run_chat_terminal
 
-    return run_chat_terminal(
-        url=url,
-        initial_query=feature_query,
-        repl=repl,
-        session_id=session_id,
+    return _run_with_qa_mode_env(
+        normalized_qa_mode,
+        lambda: run_chat_terminal(
+            url=url,
+            initial_query=feature_query,
+            repl=repl,
+            session_id=session_id,
+        ),
     )
 
 
@@ -1178,6 +1250,7 @@ def _run_terminal_benchmark_mode(*, workspace_root: Path, push_metrics: bool = F
 def run_chat(argv: Sequence[str] | None = None) -> int:
     parser = _build_common_parser("gaia chat", "Run chat mode.")
     parser.add_argument("--feature-query")
+    parser.add_argument("--qa-mode", choices=QA_MODE_CHOICES, help="Enable adaptive QA expansion for this chat run.")
     parser.add_argument("--once", action="store_true", help="Run one test and exit in terminal mode.")
     args = parser.parse_args(list(argv or []))
 
@@ -1192,6 +1265,7 @@ def run_chat(argv: Sequence[str] | None = None) -> int:
         args.feature_query,
         repl=not args.once,
         session_id=mcp_session_id,
+        qa_mode=args.qa_mode,
     )
 
 
@@ -1480,6 +1554,7 @@ def run_launcher(argv: Sequence[str] | None = None) -> int:
     parser.add_argument("--spec")
     parser.add_argument("--resume")
     parser.add_argument("--feature-query")
+    parser.add_argument("--qa-mode", choices=QA_MODE_CHOICES)
     parser.add_argument("--max-actions", type=int, default=50)
     parser.add_argument("--time-budget-seconds", type=int)
     parser.add_argument("--control", choices=CONTROL_CHOICES)
@@ -1496,6 +1571,9 @@ def run_launcher(argv: Sequence[str] | None = None) -> int:
         help="Benchmark terminal mode only: upload metrics to the configured monitoring server.",
     )
     args = parser.parse_args(list(argv or []))
+    requested_qa_mode = _normalize_qa_mode(getattr(args, "qa_mode", None))
+    if args.mode in {ADAPTIVE_QA_MODE, DEEP_ADAPTIVE_QA_MODE}:
+        requested_qa_mode = args.mode
 
     configured = _configure_session(args, require_url=False)
     if not configured:
@@ -1556,6 +1634,8 @@ def run_launcher(argv: Sequence[str] | None = None) -> int:
             forwarded += ["--resume", str(args.resume)]
         if args.mode:
             forwarded += ["--mode", str(args.mode)]
+        elif requested_qa_mode:
+            forwarded += ["--mode", requested_qa_mode]
         if args.feature_query:
             forwarded += ["--feature-query", str(args.feature_query)]
         if args.max_actions is not None:
@@ -1676,6 +1756,8 @@ def run_launcher(argv: Sequence[str] | None = None) -> int:
                 forwarded += ["--resume", str(args.resume)]
             if args.mode:
                 forwarded += ["--mode", str(args.mode)]
+            elif requested_qa_mode:
+                forwarded += ["--mode", requested_qa_mode]
             if args.feature_query:
                 forwarded += ["--feature-query", str(args.feature_query)]
             if args.max_actions is not None:
@@ -1748,6 +1830,35 @@ def run_launcher(argv: Sequence[str] | None = None) -> int:
             ),
         )
 
+    if args.mode in {ADAPTIVE_QA_MODE, DEEP_ADAPTIVE_QA_MODE} or requested_qa_mode:
+        feature_query = str(args.feature_query or "").strip()
+        if not feature_query and hasattr(sys.stdin, "isatty") and sys.stdin.isatty():
+            feature_query = _prompt_non_empty("테스트할 기능/목표")
+        if not feature_query:
+            print("QA 확장 실행에는 테스트할 기능/목표가 필요합니다.", file=sys.stderr)
+            return 2
+        _persist_profile(
+            profile,
+            provider=provider,
+            model=model,
+            auth_strategy=auth_strategy,
+            auth_method=getattr(args, "auth_method", None) or profile.get("default_openai_auth_method", "oauth"),
+            url=url,
+            runtime=runtime,
+            control_channel="local",
+            workspace=session_key,
+            session_key=session_key,
+            mcp_session_id=mcp_session_id,
+        )
+        return _dispatch_chat(
+            runtime,
+            url,
+            feature_query,
+            repl=False,
+            session_id=mcp_session_id,
+            qa_mode=requested_qa_mode,
+        )
+
     if args.mode == "chat":
         _persist_profile(
             profile,
@@ -1816,26 +1927,29 @@ def run_launcher(argv: Sequence[str] | None = None) -> int:
 
     if control == "local" and hasattr(sys.stdin, "isatty") and sys.stdin.isatty():
         quick_mode_map = {
-            "specific": "특정 기능 테스트",
-            "autonomous": "완전 자율",
+            "specific": QUICK_SPECIFIC_LABEL,
+            ADAPTIVE_QA_MODE: QUICK_ADAPTIVE_QA_LABEL,
+            DEEP_ADAPTIVE_QA_MODE: QUICK_DEEP_QA_LABEL,
+            "autonomous": QUICK_AUTONOMOUS_LABEL,
         }
         default_quick = quick_mode_map.get(
             (profile.get("last_quick_mode") or "").strip().lower(),
-            "특정 기능 테스트",
+            QUICK_SPECIFIC_LABEL,
         )
         quick_selected = _prompt_select(
             "실행 방식을 선택하세요",
-            ("특정 기능 테스트", "완전 자율"),
+            QUICK_RUN_MODE_CHOICES,
             default=default_quick,
         )
 
-        if quick_selected == "특정 기능 테스트":
+        quick_qa_mode = QUICK_QA_MODE_BY_LABEL.get(quick_selected)
+        if quick_selected in {QUICK_SPECIFIC_LABEL, QUICK_ADAPTIVE_QA_LABEL, QUICK_DEEP_QA_LABEL}:
             feature_query = (
                 str(args.feature_query).strip()
                 if args.feature_query
                 else _prompt_non_empty("테스트할 기능/목표")
             )
-            profile["last_quick_mode"] = "specific"
+            profile["last_quick_mode"] = QUICK_PROFILE_KEY_BY_LABEL.get(quick_selected, "specific")
             _persist_profile(
                 profile,
                 provider=provider,
@@ -1856,6 +1970,7 @@ def run_launcher(argv: Sequence[str] | None = None) -> int:
                 feature_query,
                 repl=False,
                 session_id=mcp_session_id,
+                qa_mode=quick_qa_mode,
             )
 
         profile["last_quick_mode"] = "autonomous"
@@ -1956,7 +2071,7 @@ def _build_start_legacy_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="gaia start", description="Legacy alias for gaia launcher.")
     subparsers = parser.add_subparsers(dest="subcommand", required=False)
     gui = subparsers.add_parser("gui")
-    gui.add_argument("--mode", choices=("plan", "ai", "chat"), default="chat")
+    gui.add_argument("--mode", choices=MODE_CHOICES, default="chat")
     gui.add_argument("--url")
     gui.add_argument("--plan")
     gui.add_argument("--spec")
@@ -1971,7 +2086,7 @@ def _build_start_legacy_parser() -> argparse.ArgumentParser:
     gui.add_argument("--session")
     gui.add_argument("--new-session", action="store_true")
     terminal = subparsers.add_parser("terminal")
-    terminal.add_argument("--mode", choices=("plan", "ai", "chat"), default="chat")
+    terminal.add_argument("--mode", choices=MODE_CHOICES, default="chat")
     terminal.add_argument("--url")
     terminal.add_argument("--plan")
     terminal.add_argument("--spec")
@@ -2049,6 +2164,11 @@ def run_start(argv: Sequence[str] | None = None) -> int:
             if parsed.feature_query:
                 forwarded += ["--feature-query", parsed.feature_query]
             return run_plan(forwarded)
+        if parsed.mode in {ADAPTIVE_QA_MODE, DEEP_ADAPTIVE_QA_MODE}:
+            forwarded += ["--mode", parsed.mode]
+            if parsed.feature_query:
+                forwarded += ["--feature-query", parsed.feature_query]
+            return run_launcher(forwarded)
         if parsed.feature_query:
             forwarded += ["--feature-query", parsed.feature_query]
         return run_chat(forwarded)
@@ -2082,6 +2202,11 @@ def run_start(argv: Sequence[str] | None = None) -> int:
             if parsed.feature_query:
                 forwarded += ["--feature-query", parsed.feature_query]
             return run_plan(forwarded)
+        if parsed.mode in {ADAPTIVE_QA_MODE, DEEP_ADAPTIVE_QA_MODE}:
+            forwarded += ["--mode", parsed.mode]
+            if parsed.feature_query:
+                forwarded += ["--feature-query", parsed.feature_query]
+            return run_launcher(forwarded)
         if parsed.feature_query:
             forwarded += ["--feature-query", parsed.feature_query]
         return run_chat(forwarded)

--- a/gaia/main.py
+++ b/gaia/main.py
@@ -34,8 +34,8 @@ def _create_parser() -> argparse.ArgumentParser:
     parser.add_argument("--spec", help="Load spec PDF in advance")
     parser.add_argument(
         "--mode",
-        choices=("plan", "ai", "chat"),
-        help="GUI startup mode (plan/ai/chat)",
+        choices=("plan", "ai", "chat", "adaptive_qa", "deep_adaptive_qa"),
+        help="GUI startup mode (plan/ai/chat/adaptive_qa/deep_adaptive_qa)",
     )
     parser.add_argument(
         "--control",

--- a/gaia/src/gui/controller.py
+++ b/gaia/src/gui/controller.py
@@ -22,6 +22,7 @@ from gaia.src.phase1.prd_ingest import ingest_prd_bundle
 from gaia.src.phase1.prd_bundle_repository import PRDBundleRepository
 from gaia.src.phase1.agent_client import AgentServiceClient
 from gaia.src.phase4.goal_driven import goals_from_scenarios, sort_goals_by_priority, TestGoal
+from gaia.src.phase4.goal_driven.adaptive_qa_runtime import ADAPTIVE_QA_MODE, DEEP_ADAPTIVE_QA_MODE
 from gaia.src.tracker.checklist import ChecklistTracker
 from gaia.src.utils.models import Assertion, TestScenario, TestStep
 from gaia.src.utils.plan_repository import PlanRepository
@@ -213,7 +214,7 @@ class AppController(QObject):
             normalized = "ai"
         elif mode == "chat":
             normalized = "quick"
-        elif mode in {"bundle", "ai", "quick", "benchmark"}:
+        elif mode in {"bundle", "ai", "quick", "benchmark", ADAPTIVE_QA_MODE, DEEP_ADAPTIVE_QA_MODE}:
             normalized = mode
         self._startup_mode = normalized
         if normalized:
@@ -229,9 +230,14 @@ class AppController(QObject):
         else:
             self._bridge_status_timer.stop()
 
-    def _build_quick_goal(self, url: str, query: str) -> TestGoal:
+    def _build_quick_goal(self, url: str, query: str, *, qa_mode: str | None = None) -> TestGoal:
         query_text = str(query or "").strip()
         words = [word for word in query_text.replace("/", " ").split() if word.strip()]
+        test_data = {"steering_policy": dict(self._active_steering_policy)} if self._active_steering_policy else {}
+        if qa_mode == ADAPTIVE_QA_MODE:
+            test_data[ADAPTIVE_QA_MODE] = {"enabled": True, "max_edge_cases": 5}
+        elif qa_mode == DEEP_ADAPTIVE_QA_MODE:
+            test_data[DEEP_ADAPTIVE_QA_MODE] = {"enabled": True, "continuous": True}
         return TestGoal(
             id=f"GUI_{int(time.time())}",
             name=(query_text[:40] or "gui quick test").strip(),
@@ -241,7 +247,7 @@ class AppController(QObject):
             success_criteria=[query_text],
             max_steps=20,
             start_url=url,
-            test_data=({"steering_policy": dict(self._active_steering_policy)} if self._active_steering_policy else {}),
+            test_data=test_data,
         )
 
     def _resolve_analysis_base_url(self) -> str:
@@ -994,14 +1000,18 @@ class AppController(QObject):
             self._start_exploratory_worker(self._current_url, max_actions=self._max_actions)
             return
 
-        if selected_mode == "quick":
+        if selected_mode in {"quick", ADAPTIVE_QA_MODE, DEEP_ADAPTIVE_QA_MODE}:
             if feature_query:
-                quick_goal = self._build_quick_goal(self._current_url, feature_query)
+                quick_goal = self._build_quick_goal(
+                    self._current_url,
+                    feature_query,
+                    qa_mode=selected_mode if selected_mode in {ADAPTIVE_QA_MODE, DEEP_ADAPTIVE_QA_MODE} else None,
+                )
                 candidate_goals = [quick_goal]
                 self._window.show_scenarios(candidate_goals)
                 self._current_execution_goal = quick_goal.name
             elif not candidate_goals:
-                self._window.append_log("⚠️ 빠른 목표 실행을 위해 테스트할 기능을 입력해주세요.")
+                self._window.append_log("⚠️ 목표 실행을 위해 테스트할 기능을 입력해주세요.")
                 return
 
         if selected_mode == "bundle" and not candidate_goals:
@@ -1023,6 +1033,10 @@ class AppController(QObject):
             )
             self._window.append_log("   ✅ 우선순위 기반 목표 실행")
             self._window.append_log("   🔎 실패 시 탐색 모드로 보완")
+            if selected_mode == ADAPTIVE_QA_MODE:
+                self._window.append_log("   🧪 Adaptive QA: 체크리스트/엣지 케이스 확장")
+            elif selected_mode == DEEP_ADAPTIVE_QA_MODE:
+                self._window.append_log("   🧪 Deep QA: 엣지 케이스를 더 공격적으로 확장")
             self._window.set_busy(True, message="AI가 목표를 수행하는 중이에요…")
             self._start_goal_worker(self._current_url, candidate_goals)
             return

--- a/gaia/src/gui/goal_worker.py
+++ b/gaia/src/gui/goal_worker.py
@@ -19,6 +19,19 @@ from gaia.src.phase4.goal_driven import (
     TestGoal,
     sort_goals_by_priority,
 )
+from gaia.src.phase4.goal_driven.adaptive_qa_runtime import (
+    ADAPTIVE_QA_MODE,
+    DEEP_ADAPTIVE_QA_MODE,
+    adaptive_qa_enabled,
+    adaptive_qa_is_deep,
+    adaptive_qa_mode,
+    build_edge_goal,
+    filter_new_edge_cases,
+    generate_adaptive_qa_plan,
+    is_adaptive_edge_goal,
+    merge_adaptive_qa_plans,
+    summarize_adaptive_qa_report,
+)
 from gaia.src.phase4.goal_driven.multi_user_interaction_runtime import close_participant_browser_contexts
 from gaia.src.tracker.checklist import ChecklistTracker
 from gaia.src.utils.config import CONFIG
@@ -121,6 +134,7 @@ class GoalDrivenWorker(QObject):
         last_reason = ""
         goal_summaries: list[dict[str, Any]] = []
         timeline_rows: list[dict[str, Any]] = []
+        adaptive_qa_reports: list[dict[str, Any]] = []
         try:
             if not self._goals:
                 self.progress.emit("ℹ️ 실행할 목표가 없습니다.")
@@ -190,17 +204,33 @@ class GoalDrivenWorker(QObject):
                     self.progress.emit(f"      이유: {result.final_reason}")
 
                 goal_timeline = _goal_step_timeline(result, goal_to_run.name)
-                goal_summaries.append(
-                    {
-                        "id": goal_to_run.id,
-                        "name": goal_to_run.name,
-                        "status": status,
-                        "reason": result.final_reason,
-                        "steps": int(result.total_steps or 0),
-                        "step_timeline": goal_timeline,
-                    }
-                )
+                goal_summary = {
+                    "id": goal_to_run.id,
+                    "name": goal_to_run.name,
+                    "status": status,
+                    "reason": result.final_reason,
+                    "steps": int(result.total_steps or 0),
+                    "step_timeline": goal_timeline,
+                }
                 timeline_rows.extend(goal_timeline)
+                if adaptive_qa_enabled(goal_to_run) and not is_adaptive_edge_goal(goal_to_run):
+                    adaptive_report = self._run_adaptive_qa_expansion(goal_to_run, result)
+                    if adaptive_report:
+                        adaptive_qa_reports.append(adaptive_report)
+                        goal_summary["adaptive_qa_report"] = adaptive_report
+                        for edge_result in list(adaptive_report.get("edge_results") or []):
+                            timeline_rows.append(
+                                {
+                                    "goal": str(edge_result.get("name") or ""),
+                                    "step": "edge",
+                                    "action": "adaptive_qa",
+                                    "duration_seconds": 0.0,
+                                    "reasoning": str(edge_result.get("reason") or ""),
+                                    "success": str(edge_result.get("status") or "").lower() == "pass",
+                                    "error": "",
+                                }
+                            )
+                goal_summaries.append(goal_summary)
                 self.scenario_finished.emit(goal_to_run.id)
 
             summary_status = "success"
@@ -211,7 +241,11 @@ class GoalDrivenWorker(QObject):
 
             self.result_ready.emit(
                 {
-                    "mode": "goal",
+                    "mode": (
+                        str(adaptive_qa_reports[0].get("mode") or ADAPTIVE_QA_MODE)
+                        if adaptive_qa_reports
+                        else "goal"
+                    ),
                     "status": summary_status,
                     "reason": last_reason or ("모든 목표가 완료되었습니다." if summary_status == "success" else "일부 목표가 실패했습니다."),
                     "total_goals": len(self._goals),
@@ -227,6 +261,7 @@ class GoalDrivenWorker(QObject):
                         for row in goal_summaries[-5:]
                         if isinstance(row, dict)
                     ],
+                    "adaptive_qa_reports": adaptive_qa_reports,
                 }
             )
         except Exception as exc:
@@ -257,6 +292,65 @@ class GoalDrivenWorker(QObject):
             except Exception:
                 pass
             self.finished.emit()
+
+    def _run_adaptive_qa_expansion(self, goal: TestGoal, primary_result: Any) -> dict[str, Any]:
+        mode = adaptive_qa_mode(goal) or ADAPTIVE_QA_MODE
+        label = "Deep QA" if mode == DEEP_ADAPTIVE_QA_MODE else "Adaptive QA"
+        self.progress.emit(f"🧪 {label}: 체크리스트와 안전 엣지 케이스를 생성합니다.")
+        is_deep = adaptive_qa_is_deep(goal)
+        plans: list[dict[str, Any]] = []
+        generated_edge_cases: list[dict[str, Any]] = []
+        seen_edge_fingerprints: set[str] = set()
+        edge_results: list[dict[str, Any]] = []
+        round_index = 1
+        while not self._cancel_requested:
+            dom = self._goal_agent._analyze_dom() or []
+            plan = generate_adaptive_qa_plan(
+                self._goal_agent,
+                goal=goal,
+                primary_result=primary_result,
+                dom_elements=dom,
+                previous_edge_cases=generated_edge_cases,
+                round_index=round_index,
+            )
+            plans.append(plan)
+            raw_edge_cases = list(plan.get("edge_cases") or []) if isinstance(plan, dict) else []
+            edge_cases = filter_new_edge_cases(raw_edge_cases, seen_edge_fingerprints)
+            if not primary_result.success or not edge_cases:
+                self.progress.emit(f"🧪 {label}: 새로 실행할 안전 엣지 케이스가 없습니다.")
+                break
+            self.progress.emit(
+                f"🧪 {label}: round {round_index} 안전 엣지 케이스 {len(edge_cases)}개 실행"
+            )
+            for edge_case in edge_cases:
+                if self._cancel_requested:
+                    break
+                generated_edge_cases.append(edge_case)
+                edge_goal = build_edge_goal(goal, edge_case, index=len(edge_results) + 1)
+                self.progress.emit(f"   [{len(edge_results) + 1}] {edge_goal.name}")
+                result = self._goal_agent.execute_goal(edge_goal)
+                edge_status = "PASS" if result.success else "FAIL"
+                edge_results.append(
+                    {
+                        "id": edge_goal.id,
+                        "name": edge_goal.name,
+                        "status": edge_status,
+                        "reason": result.final_reason,
+                        "steps": int(result.total_steps or 0),
+                    }
+                )
+                self.progress.emit(f"      {edge_status}: {result.final_reason}")
+            if not is_deep:
+                break
+            round_index += 1
+        merged_plan = merge_adaptive_qa_plans(plans)
+        merged_plan["edge_cases"] = generated_edge_cases
+        return summarize_adaptive_qa_report(
+            primary_goal=goal,
+            primary_result=primary_result,
+            plan=merged_plan,
+            edge_results=edge_results,
+        )
 
     def _on_progress(self, message: str) -> None:
         self.progress.emit(message)

--- a/gaia/src/gui/main_window.py
+++ b/gaia/src/gui/main_window.py
@@ -791,6 +791,8 @@ CASE_MODE_PALETTE: dict[str, tuple[str, str, str]] = {
     "benchmark_all": ("▶",  "#eff6ff", "#3182f6"),
     "benchmark":     ("◉",  "#eff6ff", "#3182f6"),
     "quick":         ("⚡",  "#eff6ff", "#3182f6"),
+    "adaptive_qa":   ("▣",  "#eff6ff", "#3182f6"),
+    "deep_adaptive_qa": ("◆", "#eef2ff", "#4f46e5"),
     "ai":            ("✦",  "#eff6ff", "#3182f6"),
     "spec":          ("▤",  "#eff6ff", "#3182f6"),
     "bundle":        ("▦",  "#eff6ff", "#3182f6"),
@@ -832,6 +834,24 @@ DEFAULT_TEST_CASES: list[dict[str, Any]] = [
         "title": "빠른 목표 직접 입력",
         "desc": "AI가 직접 목표를 이해하고 수행합니다 (단일 실행).",
         "eta": "예상 소요 1~3분",
+        "recommended": False,
+    },
+    {
+        "id": "adaptive_qa_goal",
+        "mode": "adaptive_qa",
+        "icon_mode": "adaptive_qa",
+        "title": "QA 확장 실행",
+        "desc": "목표 수행 후 안전 엣지 케이스를 최대 5개 확장합니다.",
+        "eta": "예상 소요 5~10분",
+        "recommended": False,
+    },
+    {
+        "id": "deep_adaptive_qa_goal",
+        "mode": "deep_adaptive_qa",
+        "icon_mode": "deep_adaptive_qa",
+        "title": "Deep QA 확장 실행",
+        "desc": "새로운 안전 엣지 케이스가 더 이상 없을 때까지 계속 확장합니다.",
+        "eta": "예상 소요 가변",
         "recommended": False,
     },
     {
@@ -4578,7 +4598,7 @@ class MainWindow(QMainWindow):
 
         섹션 분리:
           - 섹션 1 (_case_rows_layout): mode in {benchmark, ai} → 등록된 테스트 케이스
-          - 섹션 2 (_freeform_rows_layout): mode in {quick, bundle} → AI 자율 실행
+          - 섹션 2 (_freeform_rows_layout): mode in {quick, adaptive_qa, deep_adaptive_qa, bundle} → AI 자율 실행
         """
         # 양쪽 컨테이너 초기화
         for layout in (self._case_rows_layout, getattr(self, "_freeform_rows_layout", None)):
@@ -4594,8 +4614,8 @@ class MainWindow(QMainWindow):
 
         for case in cases:
             mode = str(case.get("mode", "benchmark"))
-            # quick/bundle은 freeform 섹션, 나머지는 메인 섹션
-            is_freeform = mode in ("quick", "bundle")
+            # quick/adaptive/deep/bundle은 freeform 섹션, 나머지는 메인 섹션
+            is_freeform = mode in ("quick", "adaptive_qa", "deep_adaptive_qa", "bundle")
             target_parent = self._freeform_rows_container if is_freeform else self._case_rows_container
             target_layout = self._freeform_rows_layout if is_freeform else self._case_rows_layout
 
@@ -4712,6 +4732,26 @@ class MainWindow(QMainWindow):
                 "scenario_id": "",
             },
             {
+                "id": "adaptive_qa_goal",
+                "mode": "adaptive_qa",
+                "icon_mode": "adaptive_qa",
+                "title": "QA 확장 실행",
+                "desc": "목표 수행 후 안전 엣지 케이스를 최대 5개 확장합니다.",
+                "eta": "예상 소요 5~10분",
+                "recommended": False,
+                "scenario_id": "",
+            },
+            {
+                "id": "deep_adaptive_qa_goal",
+                "mode": "deep_adaptive_qa",
+                "icon_mode": "deep_adaptive_qa",
+                "title": "Deep QA 확장 실행",
+                "desc": "새로운 안전 엣지 케이스가 더 이상 없을 때까지 계속 확장합니다.",
+                "eta": "예상 소요 가변",
+                "recommended": False,
+                "scenario_id": "",
+            },
+            {
                 "id": "ai_explore",
                 "mode": "ai",
                 "icon_mode": "ai",
@@ -4795,7 +4835,7 @@ class MainWindow(QMainWindow):
                 title = row._title_label.text().lower()  # noqa: SLF001
                 cat_ok = False
                 if cat_sel == "기본":
-                    cat_ok = mode.startswith("benchmark") or mode == "quick"
+                    cat_ok = mode.startswith("benchmark") or mode in {"quick", "adaptive_qa", "deep_adaptive_qa"}
                 elif cat_sel == "검색":
                     cat_ok = "검색" in title or "search" in mode
                 elif cat_sel == "AI":
@@ -4821,7 +4861,7 @@ class MainWindow(QMainWindow):
         상호 배타 규칙:
         - "benchmark_all"(전체 시나리오) 선택 → 개별 시나리오 모두 해제
         - 개별 시나리오 선택 → "benchmark_all" 자동 해제
-        - 섹션 2(AI 자율 실행: quick/bundle)는 단일 선택 — 하나 선택 시 다른 모두 해제
+        - 섹션 2(AI 자율 실행: quick/adaptive_qa/deep_adaptive_qa/bundle)는 단일 선택 — 하나 선택 시 다른 모두 해제
         - 섹션 2 카드 선택 시 → 섹션 1(테스트 케이스) 모두 자동 해제 (모드 충돌 방지)
         - 섹션 1 카드 선택 시 → 섹션 2 모두 자동 해제
         """
@@ -4943,15 +4983,15 @@ class MainWindow(QMainWindow):
         # 기본: scenario_ids 초기화
         self._pending_scenario_ids = None
 
-        if mode == "quick":
-            # 빠른 목표 — 사용자 정의 QuickGoalInputDialog (multiline + 예시 + 카운터)
+        if mode in {"quick", "adaptive_qa", "deep_adaptive_qa"}:
+            # 빠른 목표 / QA 확장 — 사용자 정의 QuickGoalInputDialog (multiline + 예시 + 카운터)
             existing = self.get_feature_query().strip() if hasattr(self, "get_feature_query") else ""
             dlg = QuickGoalInputDialog(self, initial_text=existing)
             if dlg.exec() != QDialog.DialogCode.Accepted:
                 return  # 사용자 취소
             goal = dlg.goal_text()
             if not goal:
-                NotificationDialog.info(self, "목표 필요", "빠른 목표 모드는 목표 텍스트가 필요합니다.")
+                NotificationDialog.info(self, "목표 필요", "목표 텍스트가 필요합니다.")
                 return
             self.set_feature_query(goal)
             self.startRequested.emit()
@@ -5111,6 +5151,20 @@ class MainWindow(QMainWindow):
         self._quick_mode_button.clicked.connect(lambda: self.set_selected_run_mode("quick"))
         self._run_mode_group.addButton(self._quick_mode_button)
         mode_row.addWidget(self._quick_mode_button)
+
+        self._adaptive_qa_mode_button = QPushButton("QA 확장", page)
+        self._adaptive_qa_mode_button.setCheckable(True)
+        self._adaptive_qa_mode_button.setProperty("modeButton", True)
+        self._adaptive_qa_mode_button.clicked.connect(lambda: self.set_selected_run_mode("adaptive_qa"))
+        self._run_mode_group.addButton(self._adaptive_qa_mode_button)
+        mode_row.addWidget(self._adaptive_qa_mode_button)
+
+        self._deep_adaptive_qa_mode_button = QPushButton("Deep QA", page)
+        self._deep_adaptive_qa_mode_button.setCheckable(True)
+        self._deep_adaptive_qa_mode_button.setProperty("modeButton", True)
+        self._deep_adaptive_qa_mode_button.clicked.connect(lambda: self.set_selected_run_mode("deep_adaptive_qa"))
+        self._run_mode_group.addButton(self._deep_adaptive_qa_mode_button)
+        mode_row.addWidget(self._deep_adaptive_qa_mode_button)
 
         self._ai_mode_button = QPushButton("완전 자율", page)
         self._ai_mode_button.setCheckable(True)
@@ -6572,7 +6626,7 @@ class MainWindow(QMainWindow):
             return
         self._feature_input.setText(query)
         self._current_feature_query = query.strip()
-        self._feature_input_container.setVisible(self._selected_run_mode == "quick")
+        self._feature_input_container.setVisible(self._selected_run_mode in {"quick", "adaptive_qa", "deep_adaptive_qa"})
 
     def set_benchmark_catalog(
         self,
@@ -7211,10 +7265,12 @@ class MainWindow(QMainWindow):
         self._emit_benchmark_manage()
 
     def set_selected_run_mode(self, mode: str) -> None:
-        normalized = mode if mode in {"quick", "ai", "bundle", "benchmark"} else "quick"
+        normalized = mode if mode in {"quick", "adaptive_qa", "deep_adaptive_qa", "ai", "bundle", "benchmark"} else "quick"
         self._selected_run_mode = normalized
         mapping = {
             "quick": getattr(self, "_quick_mode_button", None),
+            "adaptive_qa": getattr(self, "_adaptive_qa_mode_button", None),
+            "deep_adaptive_qa": getattr(self, "_deep_adaptive_qa_mode_button", None),
             "ai": getattr(self, "_ai_mode_button", None),
             "bundle": getattr(self, "_bundle_mode_button", None),
             "benchmark": getattr(self, "_benchmark_mode_button", None),
@@ -7228,7 +7284,7 @@ class MainWindow(QMainWindow):
             button.style().unpolish(button)
             button.style().polish(button)
         if hasattr(self, "_feature_input_container"):
-            self._feature_input_container.setVisible(normalized == "quick")
+            self._feature_input_container.setVisible(normalized in {"quick", "adaptive_qa", "deep_adaptive_qa"})
         if hasattr(self, "_standard_action_container"):
             self._standard_action_container.setVisible(normalized != "benchmark")
         # 신규 3단계 UX: mode 변경만으로 stage를 자동 전환하지 않음.

--- a/gaia/src/phase4/goal_driven/adaptive_qa_runtime.py
+++ b/gaia/src/phase4/goal_driven/adaptive_qa_runtime.py
@@ -1,0 +1,493 @@
+"""Adaptive QA expansion helpers for goal-driven runs.
+
+This module keeps the experimental QA-expansion mode outside the default
+goal loop. The normal runner still executes the user's primary goal first;
+only when explicitly enabled do we generate safe follow-up edge cases from
+the observed page state and run them as additional goals.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any, Dict, Iterable, List, Optional
+
+from .models import GoalResult, TestGoal
+
+
+ADAPTIVE_QA_MODE = "adaptive_qa"
+DEEP_ADAPTIVE_QA_MODE = "deep_adaptive_qa"
+_DEFAULT_MAX_EDGE_CASES = 5
+_DEFAULT_DEEP_MAX_EDGE_CASES = 10
+_ADAPTIVE_EDGE_CASE_CAP = 5
+_DEEP_EDGE_CASE_CAP = 15
+
+_RISKY_EDGE_TOKENS = (
+    "결제",
+    "구매",
+    "주문",
+    "예약",
+    "삭제",
+    "탈퇴",
+    "가입",
+    "checkout",
+    "purchase",
+    "order",
+    "delete",
+    "reserve",
+)
+
+
+def adaptive_qa_enabled(goal: TestGoal) -> bool:
+    return adaptive_qa_mode(goal) is not None
+
+
+def adaptive_qa_is_deep(goal: TestGoal) -> bool:
+    return adaptive_qa_mode(goal) == DEEP_ADAPTIVE_QA_MODE
+
+
+def adaptive_qa_mode(goal: TestGoal) -> str | None:
+    data = goal.test_data if isinstance(goal.test_data, dict) else {}
+    raw_deep = data.get(DEEP_ADAPTIVE_QA_MODE)
+    if isinstance(raw_deep, dict):
+        enabled = raw_deep.get("enabled", True)
+        if str(enabled).strip().lower() not in {"0", "false", "no", "off", "disabled"}:
+            return DEEP_ADAPTIVE_QA_MODE
+    elif raw_deep is not None and str(raw_deep).strip().lower() not in {"0", "false", "no", "off", "disabled"}:
+        return DEEP_ADAPTIVE_QA_MODE
+
+    raw = data.get(ADAPTIVE_QA_MODE)
+    if isinstance(raw, dict):
+        enabled = raw.get("enabled", True)
+        if str(enabled).strip().lower() not in {"0", "false", "no", "off", "disabled"}:
+            raw_mode = str(raw.get("mode") or "").strip().lower()
+            return DEEP_ADAPTIVE_QA_MODE if raw_mode in {"deep", "deep_qa", DEEP_ADAPTIVE_QA_MODE} else ADAPTIVE_QA_MODE
+    elif raw is not None and str(raw).strip().lower() not in {"0", "false", "no", "off", "disabled"}:
+        return ADAPTIVE_QA_MODE
+
+    qa_mode = str(data.get("qa_mode") or data.get("mode") or "").strip().lower()
+    if qa_mode in {DEEP_ADAPTIVE_QA_MODE, "deep", "deep_qa", "aggressive_qa", "deep_adaptive"}:
+        return DEEP_ADAPTIVE_QA_MODE
+    if qa_mode in {ADAPTIVE_QA_MODE, "adaptive", "qa_adaptive", "progressive_qa"}:
+        return ADAPTIVE_QA_MODE
+    return None
+
+
+def is_adaptive_edge_goal(goal: TestGoal) -> bool:
+    data = goal.test_data if isinstance(goal.test_data, dict) else {}
+    return bool(data.get("adaptive_qa_edge_case"))
+
+
+def adaptive_qa_max_edge_cases(goal: TestGoal) -> int:
+    data = goal.test_data if isinstance(goal.test_data, dict) else {}
+    mode = adaptive_qa_mode(goal)
+    raw_config = data.get(DEEP_ADAPTIVE_QA_MODE) if mode == DEEP_ADAPTIVE_QA_MODE else data.get(ADAPTIVE_QA_MODE)
+    raw_value = raw_config.get("max_edge_cases") if isinstance(raw_config, dict) else data.get("adaptive_qa_max_edge_cases")
+    try:
+        value = int(raw_value)
+    except Exception:
+        value = _DEFAULT_DEEP_MAX_EDGE_CASES if mode == DEEP_ADAPTIVE_QA_MODE else _DEFAULT_MAX_EDGE_CASES
+    cap = _DEEP_EDGE_CASE_CAP if mode == DEEP_ADAPTIVE_QA_MODE else _ADAPTIVE_EDGE_CASE_CAP
+    return max(0, min(value, cap))
+
+
+def _strip_code_fences(text: str) -> str:
+    value = str(text or "").strip()
+    if value.startswith("```json"):
+        value = value[7:].strip()
+    elif value.startswith("```"):
+        value = value[3:].strip()
+    if value.endswith("```"):
+        value = value[:-3].strip()
+    return value
+
+
+def _parse_json_object(text: str) -> Dict[str, Any]:
+    cleaned = _strip_code_fences(text)
+    try:
+        data = json.loads(cleaned)
+    except Exception:
+        match = re.search(r"\{.*\}", cleaned, flags=re.S)
+        if not match:
+            return {}
+        try:
+            data = json.loads(match.group(0))
+        except Exception:
+            return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _truncate(text: Any, limit: int = 180) -> str:
+    value = str(text or "").replace("\n", " ").strip()
+    if len(value) <= limit:
+        return value
+    return value[: max(0, limit - 1)].rstrip() + "…"
+
+
+def _format_dom_for_adaptive_prompt(agent: Any, dom_elements: Iterable[Any]) -> str:
+    formatter = getattr(agent, "_format_dom_for_llm", None)
+    if callable(formatter):
+        try:
+            formatted = str(formatter(list(dom_elements or [])) or "").strip()
+            if formatted:
+                return formatted[:12000]
+        except Exception:
+            pass
+    lines: list[str] = []
+    for element in list(dom_elements or [])[:80]:
+        parts = []
+        for attr in ("role", "tag", "text", "aria_label", "context_text"):
+            value = _truncate(getattr(element, attr, ""), 140)
+            if value:
+                parts.append(f"{attr}={value}")
+        if parts:
+            lines.append("- " + " | ".join(parts))
+    return "\n".join(lines)[:12000]
+
+
+def _safe_slug(value: str, fallback: str) -> str:
+    slug = re.sub(r"[^a-zA-Z0-9_]+", "_", str(value or "").strip()).strip("_")
+    return (slug or fallback)[:48]
+
+
+def _is_safe_edge_case(edge: Dict[str, Any]) -> bool:
+    safety = str(edge.get("safety") or edge.get("risk") or "safe").strip().lower()
+    if safety in {"unsafe", "dangerous", "risky", "blocked"}:
+        return False
+    blob = " ".join(
+        str(edge.get(key) or "")
+        for key in ("id", "name", "description", "reason", "expected_outcome")
+    ).lower()
+    return not any(token in blob for token in _RISKY_EDGE_TOKENS)
+
+
+def _normalize_checks(raw_checks: Any) -> list[dict[str, Any]]:
+    checks: list[dict[str, Any]] = []
+    if not isinstance(raw_checks, list):
+        return checks
+    for idx, item in enumerate(raw_checks, start=1):
+        if not isinstance(item, dict):
+            continue
+        title = _truncate(item.get("title") or item.get("name") or item.get("id") or "", 120)
+        if not title:
+            continue
+        checks.append(
+            {
+                "id": _safe_slug(str(item.get("id") or title), f"check_{idx}"),
+                "title": title,
+                "source": "agent_inferred",
+                "status": "DISCOVERED",
+                "rationale": _truncate(item.get("rationale") or item.get("reason") or "", 240),
+                "evidence_hint": _truncate(item.get("evidence_hint") or item.get("evidence") or "", 240),
+            }
+        )
+    return checks[:8]
+
+
+def _normalize_edge_cases(raw_edges: Any, *, max_edge_cases: int) -> list[dict[str, Any]]:
+    edges: list[dict[str, Any]] = []
+    if max_edge_cases <= 0 or not isinstance(raw_edges, list):
+        return edges
+    for idx, item in enumerate(raw_edges, start=1):
+        if not isinstance(item, dict):
+            continue
+        title = _truncate(item.get("name") or item.get("title") or item.get("id") or "", 120)
+        description = _truncate(item.get("description") or item.get("goal") or title, 360)
+        if not title or not description:
+            continue
+        edge = {
+            "id": _safe_slug(str(item.get("id") or title), f"edge_{idx}"),
+            "name": title,
+            "description": description,
+            "dimension": _truncate(item.get("dimension") or item.get("axis") or item.get("category") or "", 120),
+            "reason": _truncate(item.get("reason") or item.get("rationale") or "", 240),
+            "safety": str(item.get("safety") or "safe_readonly_or_reversible").strip(),
+            "success_criteria": [
+                _truncate(value, 180)
+                for value in list(item.get("success_criteria") or item.get("checks") or [])
+                if str(value or "").strip()
+            ][:4],
+        }
+        if _is_safe_edge_case(edge):
+            edges.append(edge)
+        if len(edges) >= max_edge_cases:
+            break
+    return edges
+
+
+def edge_case_fingerprint(edge_case: Dict[str, Any]) -> str:
+    fields = [
+        str(edge_case.get("id") or ""),
+        str(edge_case.get("dimension") or ""),
+        str(edge_case.get("name") or ""),
+        str(edge_case.get("description") or ""),
+    ]
+    blob = " ".join(field.strip().lower() for field in fields if field.strip())
+    blob = re.sub(r"\s+", " ", blob)
+    blob = re.sub(r"[^0-9a-zA-Z가-힣 ]+", "", blob)
+    return blob[:240]
+
+
+def filter_new_edge_cases(
+    edge_cases: Iterable[Dict[str, Any]],
+    seen_fingerprints: set[str],
+) -> list[dict[str, Any]]:
+    new_cases: list[dict[str, Any]] = []
+    for edge_case in edge_cases:
+        fingerprint = edge_case_fingerprint(edge_case)
+        if not fingerprint or fingerprint in seen_fingerprints:
+            continue
+        seen_fingerprints.add(fingerprint)
+        new_cases.append(dict(edge_case))
+    return new_cases
+
+
+def merge_adaptive_qa_plans(plans: Iterable[Dict[str, Any]]) -> dict[str, Any]:
+    plan_list = [dict(plan) for plan in plans if isinstance(plan, dict)]
+    checks: list[dict[str, Any]] = []
+    check_ids: set[str] = set()
+    edge_cases: list[dict[str, Any]] = []
+    edge_fingerprints: set[str] = set()
+    mode = ADAPTIVE_QA_MODE
+    status = "generated" if plan_list else "not_generated"
+    for plan in plan_list:
+        mode = str(plan.get("mode") or mode)
+        status = str(plan.get("status") or status)
+        for check in list(plan.get("checks") or []):
+            if not isinstance(check, dict):
+                continue
+            check_id = str(check.get("id") or check.get("title") or "").strip()
+            if not check_id or check_id in check_ids:
+                continue
+            check_ids.add(check_id)
+            checks.append(dict(check))
+        for edge_case in list(plan.get("edge_cases") or []):
+            if not isinstance(edge_case, dict):
+                continue
+            fingerprint = edge_case_fingerprint(edge_case)
+            if not fingerprint or fingerprint in edge_fingerprints:
+                continue
+            edge_fingerprints.add(fingerprint)
+            edge_cases.append(dict(edge_case))
+    return {
+        "enabled": bool(plan_list),
+        "mode": mode,
+        "status": status,
+        "round_count": len(plan_list),
+        "checks": checks,
+        "edge_cases": edge_cases,
+    }
+
+
+def generate_adaptive_qa_plan(
+    agent: Any,
+    *,
+    goal: TestGoal,
+    primary_result: GoalResult,
+    dom_elements: Optional[List[Any]] = None,
+    max_edge_cases: Optional[int] = None,
+    previous_edge_cases: Optional[List[Dict[str, Any]]] = None,
+    round_index: int = 1,
+) -> dict[str, Any]:
+    """Ask the model for inferred QA checks and safe follow-up edge cases."""
+
+    if is_adaptive_edge_goal(goal):
+        return {"enabled": False, "reason": "edge_case_goals_do_not_expand"}
+    mode = adaptive_qa_mode(goal) or ADAPTIVE_QA_MODE
+    edge_cap = _DEEP_EDGE_CASE_CAP if mode == DEEP_ADAPTIVE_QA_MODE else _ADAPTIVE_EDGE_CASE_CAP
+    edge_limit = adaptive_qa_max_edge_cases(goal) if max_edge_cases is None else max(0, min(int(max_edge_cases), edge_cap))
+    expansion_style = (
+        "공격적 Deep QA 모드다. 특정 서비스/도메인 이름이나 고정 예시를 가정하지 말고, 현재 DOM과 최근 행동에서 관찰되는 조작 가능한 surface와 검증 가능한 출력 surface를 먼저 추론하라. "
+        "반복되는 컨트롤, 선택형 컨트롤, 입력 surface, 목록/표/카드, 내비게이션, 상태 표시, 결과 수치, 오류/빈 상태처럼 화면에 실제 존재하는 affordance를 서로 다른 variation dimension으로 나누고, 각 dimension에서 사람이 놓치기 쉬운 검증 목표를 최대한 많이 제안하라."
+        if mode == DEEP_ADAPTIVE_QA_MODE
+        else "일반 Adaptive QA 모드다. 현재 화면에서 가장 안전하고 직접적인 follow-up 검증만 고른다."
+    )
+    dom = list(dom_elements or [])
+    formatted_dom = _format_dom_for_adaptive_prompt(agent, dom)
+    action_history = [
+        _truncate(item, 220)
+        for item in list(getattr(agent, "_action_history", []) or [])[-8:]
+        if str(item or "").strip()
+    ]
+    action_feedback = [
+        _truncate(item, 220)
+        for item in list(getattr(agent, "_action_feedback", []) or [])[-8:]
+        if str(item or "").strip()
+    ]
+    previous_edges = [
+        {
+            "id": _truncate(item.get("id"), 80),
+            "dimension": _truncate(item.get("dimension"), 120),
+            "name": _truncate(item.get("name"), 120),
+            "description": _truncate(item.get("description"), 240),
+        }
+        for item in list(previous_edge_cases or [])[-30:]
+        if isinstance(item, dict)
+    ]
+    prompt = f"""너는 웹 QA 리드다. 사용자가 요청한 primary test를 방금 실행했다.
+현재 화면과 최근 행동을 보고, 시중 사이트에서 안전하게 추가 검증할 수 있는 QA 체크와 엣지 케이스를 생성하라.
+{expansion_style}
+
+사용자 목표:
+{goal.description}
+
+primary 실행 결과:
+- status: {'PASS' if primary_result.success else 'FAIL'}
+- reason: {primary_result.final_reason}
+- steps: {primary_result.total_steps}
+
+최근 액션:
+{json.dumps(action_history, ensure_ascii=False)}
+
+최근 피드백:
+{json.dumps(action_feedback, ensure_ascii=False)}
+
+이미 제안/실행된 엣지 케이스:
+{json.dumps(previous_edges, ensure_ascii=False)}
+
+현재 DOM:
+{formatted_dom or '(없음)'}
+
+규칙:
+- 사용자가 명시한 목표는 완화하지 마라.
+- 실제 화면에서 관찰 가능한 UI affordance를 근거로 체크를 만들라.
+- 이미 제안/실행된 엣지 케이스와 같은 목표, 같은 dimension, 같은 화면 확인을 반복하지 마라.
+- edge_cases는 결제/구매/주문/예약/삭제/탈퇴/가입/개인정보 변경처럼 비용이 발생하거나 복구가 어려운 행동을 제안하지 마라.
+- 사용자가 명시적으로 허용한 메일/메시지 전송은 가능하지만, 수신자와 내용이 명확하지 않으면 제안하지 마라.
+- primary가 실패했으면 edge_cases는 빈 배열로 둔다.
+- edge_cases는 이번 라운드에서 최대 {edge_limit}개만 제안한다.
+- deep mode에서는 같은 dimension만 반복하지 말고, 화면에서 관찰 가능한 서로 다른 검증 축을 넓게 덮어라.
+- 각 edge case는 GAIA가 자연어 goal로 바로 실행할 수 있어야 한다.
+
+JSON만 출력:
+{{
+  "checks": [
+    {{
+      "id": "snake_case_id",
+      "title": "체크 이름",
+      "rationale": "왜 이 체크가 필요한지",
+      "evidence_hint": "어떤 화면 증거로 판정할지"
+    }}
+  ],
+  "edge_cases": [
+    {{
+      "id": "snake_case_id",
+      "name": "엣지 케이스 이름",
+      "dimension": "이 케이스가 덮는 검증 축",
+      "description": "GAIA가 실행할 자연어 목표",
+      "reason": "왜 확장했는지",
+      "safety": "safe_readonly_or_reversible",
+      "success_criteria": ["판정 조건"]
+    }}
+  ]
+}}"""
+
+    raw = ""
+    try:
+        raw = str(agent._call_llm_text_only(prompt) or "")
+    except Exception as exc:
+        return {
+            "enabled": True,
+            "mode": mode,
+            "round_index": round_index,
+            "status": "generation_failed",
+            "reason": str(exc)[:240],
+            "checks": [],
+            "edge_cases": [],
+        }
+    parsed = _parse_json_object(raw)
+    checks = _normalize_checks(parsed.get("checks"))
+    edges = _normalize_edge_cases(parsed.get("edge_cases"), max_edge_cases=edge_limit if primary_result.success else 0)
+    return {
+        "enabled": True,
+        "mode": mode,
+        "round_index": round_index,
+        "status": "generated",
+        "raw_response": raw[:4000],
+        "checks": checks,
+        "edge_cases": edges,
+    }
+
+
+def build_edge_goal(parent_goal: TestGoal, edge_case: Dict[str, Any], *, index: int) -> TestGoal:
+    data = dict(parent_goal.test_data or {})
+    data.pop(ADAPTIVE_QA_MODE, None)
+    data.pop(DEEP_ADAPTIVE_QA_MODE, None)
+    for key in ("qa_mode", "mode"):
+        if str(data.get(key) or "").strip().lower() in {
+            ADAPTIVE_QA_MODE,
+            DEEP_ADAPTIVE_QA_MODE,
+            "adaptive",
+            "qa_adaptive",
+            "progressive_qa",
+            "deep",
+            "deep_qa",
+            "aggressive_qa",
+            "deep_adaptive",
+        }:
+            data.pop(key, None)
+    data["adaptive_qa_edge_case"] = True
+    data["adaptive_qa_parent_goal_id"] = parent_goal.id
+    criteria = [
+        str(value or "").strip()
+        for value in list(edge_case.get("success_criteria") or [])
+        if str(value or "").strip()
+    ]
+    description = str(edge_case.get("description") or edge_case.get("name") or "").strip()
+    return TestGoal(
+        id=f"{parent_goal.id}_EDGE_{index}",
+        name=str(edge_case.get("name") or f"Adaptive edge case {index}")[:80],
+        description=description,
+        priority="SHOULD",
+        keywords=list(parent_goal.keywords or [])[:5],
+        preconditions=list(parent_goal.preconditions or []),
+        test_data=data,
+        success_criteria=criteria or [description],
+        expected_signals=list(parent_goal.expected_signals or []),
+        max_steps=max(3, min(int(parent_goal.max_steps or 20), 8)),
+        # Edge goals intentionally continue from the observed post-primary page.
+        # Re-navigating to the original start URL would erase the UI state that
+        # motivated the generated edge case.
+        start_url=None,
+    )
+
+
+def summarize_adaptive_qa_report(
+    *,
+    primary_goal: TestGoal,
+    primary_result: GoalResult,
+    plan: Dict[str, Any],
+    edge_results: List[Dict[str, Any]],
+) -> dict[str, Any]:
+    generated_edges = list(plan.get("edge_cases") or []) if isinstance(plan, dict) else []
+    executed = len(edge_results)
+    passed = sum(1 for item in edge_results if str(item.get("status") or "").lower() == "pass")
+    failed = sum(1 for item in edge_results if str(item.get("status") or "").lower() == "fail")
+    checks = [
+        {
+            "id": "primary_goal",
+            "title": primary_goal.description,
+            "source": "user_explicit",
+            "status": "PASS" if primary_result.success else "FAIL",
+            "evidence": primary_result.final_reason,
+        }
+    ]
+    checks.extend(list(plan.get("checks") or []) if isinstance(plan, dict) else [])
+    total_scored = 1 + executed
+    score = (int(primary_result.success) + passed) / total_scored if total_scored else 0.0
+    mode = str(plan.get("mode") or adaptive_qa_mode(primary_goal) or ADAPTIVE_QA_MODE) if isinstance(plan, dict) else ADAPTIVE_QA_MODE
+    return {
+        "mode": mode,
+        "summary": {
+            "primary_status": "PASS" if primary_result.success else "FAIL",
+            "generated_check_count": max(0, len(checks) - 1),
+            "generated_edge_case_count": len(generated_edges),
+            "executed_edge_case_count": executed,
+            "passed_edge_case_count": passed,
+            "failed_edge_case_count": failed,
+            "score": round(score, 3),
+        },
+        "checks": checks,
+        "edge_cases": generated_edges,
+        "edge_results": edge_results,
+    }

--- a/gaia/src/phase4/goal_driven/constraints.py
+++ b/gaia/src/phase4/goal_driven/constraints.py
@@ -75,6 +75,19 @@ def _looks_like_instructional_target_token(token: str) -> bool:
     return any(hint in value for hint in instructional_hints)
 
 
+def _strip_negated_action_clauses(text: str) -> str:
+    """Remove clauses that describe actions the user explicitly forbids."""
+
+    value = str(text or "")
+    if not value:
+        return ""
+    negation_pattern = re.compile(
+        r"[^.!?。;\n]*(?:하지\s*마|하지\s*말|하지마|하지말|절대\s*하지|금지|do\s+not|don't|never|must\s+not)[^.!?。;\n]*",
+        flags=re.IGNORECASE,
+    )
+    return negation_pattern.sub(" ", value)
+
+
 def derive_goal_constraints(goal_blob: str, normalize_text: NormalizeTextFn) -> Dict[str, Any]:
     text = normalize_text(goal_blob)
     if not text:
@@ -124,10 +137,11 @@ def derive_goal_constraints(goal_blob: str, normalize_text: NormalizeTextFn) -> 
     increase_hints = ("증가", "늘", "담", "추가", "add", "append", "increase", "grow", "more")
     decrease_hints = ("감소", "줄", "제거", "삭제", "remove", "decrease", "less")
     clear_hints = ("비우", "비웠", "전체 삭제", "전부 삭제", "clear", "empty", "remove all")
+    mutation_text = _strip_negated_action_clauses(text)
     mutation_text = re.sub(
         r"추가\s*(?:인증|확인|보안|로그인|otp|2fa)",
         " ",
-        text,
+        mutation_text,
         flags=re.IGNORECASE,
     )
     has_increase = any(hint in mutation_text for hint in increase_hints)

--- a/gaia/src/phase4/goal_driven/goal_completion_helpers.py
+++ b/gaia/src/phase4/goal_driven/goal_completion_helpers.py
@@ -273,6 +273,48 @@ def requires_explicit_submission_completion(agent, goal: TestGoal) -> bool:
     )
 
 
+def requires_interactive_state_change_completion(agent, goal: TestGoal) -> bool:
+    """Visibility of the control itself is not enough for filter/sort/select goals."""
+
+    goal_blob = agent._normalize_text(agent._goal_text_blob(goal))
+    if not goal_blob:
+        return False
+    action_tokens = (
+        "필터",
+        "정렬",
+        "선택",
+        "적용",
+        "전환",
+        "변경",
+        "바뀌",
+        "반영",
+        "옵션",
+        "filter",
+        "sort",
+        "select",
+        "apply",
+        "change",
+        "switch",
+    )
+    result_tokens = (
+        "결과",
+        "목록",
+        "리스트",
+        "상위",
+        "카드",
+        "표",
+        "순서",
+        "result",
+        "list",
+        "card",
+        "table",
+        "order",
+    )
+    return any(token in goal_blob for token in action_tokens) and any(
+        token in goal_blob for token in result_tokens
+    )
+
+
 def evaluate_readonly_visibility_completion(
     agent,
     *,
@@ -467,6 +509,8 @@ def evaluate_goal_target_completion(
     if is_readonly_visibility_goal(agent, goal):
         return None
     if requires_explicit_submission_completion(agent, goal):
+        return None
+    if requires_interactive_state_change_completion(agent, goal):
         return None
     direction = str(agent._goal_constraints.get("mutation_direction") or "").strip().lower()
     if direction not in {"increase", "decrease", "clear"}:

--- a/gaia/src/phase4/goal_driven/goal_completion_helpers.py
+++ b/gaia/src/phase4/goal_driven/goal_completion_helpers.py
@@ -315,6 +315,164 @@ def requires_interactive_state_change_completion(agent, goal: TestGoal) -> bool:
     )
 
 
+def _goal_requests_payment_presubmit(agent, goal: TestGoal) -> bool:
+    goal_blob = agent._normalize_text(agent._goal_text_blob(goal))
+    if not goal_blob:
+        return False
+    payment_tokens = (
+        "결제",
+        "결재",
+        "payment",
+        "pay",
+        "checkout",
+    )
+    boundary_tokens = (
+        "직전",
+        "전까지",
+        "전 단계",
+        "이전 단계",
+        "누르지",
+        "누르지 않",
+        "누르기 전",
+        "버튼이 보이",
+        "버튼 표시",
+        "결제창",
+        "결제 창",
+        "주문/결제 화면",
+        "주문 결제 화면",
+        "before payment",
+        "before paying",
+        "before checkout",
+        "payment page",
+        "checkout page",
+        "pre-submit",
+    )
+    completion_tokens = (
+        "결제 완료",
+        "결제 성공",
+        "결제를 완료",
+        "결제하기를 눌",
+        "결제 버튼을 눌",
+        "결제까지 완료",
+        "구매 완료",
+        "주문 완료",
+        "complete payment",
+        "payment complete",
+        "complete purchase",
+        "place order",
+    )
+    if any(token in goal_blob for token in completion_tokens) and not any(
+        token in goal_blob for token in boundary_tokens
+    ):
+        return False
+    return any(token in goal_blob for token in payment_tokens) and any(
+        token in goal_blob for token in boundary_tokens
+    )
+
+
+def _payment_presubmit_blob(agent, el: DOMElement) -> str:
+    labels = getattr(el, "group_action_labels", None) or []
+    label_blob = " ".join(str(item or "") for item in labels if str(item or "").strip()) if isinstance(labels, list) else ""
+    return agent._normalize_text(
+        " ".join(
+            [
+                str(getattr(el, "text", "") or ""),
+                str(getattr(el, "aria_label", "") or ""),
+                str(getattr(el, "title", "") or ""),
+                str(getattr(el, "role_ref_name", "") or ""),
+                str(getattr(el, "placeholder", "") or ""),
+                str(getattr(el, "container_name", "") or ""),
+                str(getattr(el, "container_role", "") or ""),
+                str(getattr(el, "context_text", "") or ""),
+                label_blob,
+            ]
+        )
+    )
+
+
+def evaluate_payment_presubmit_completion(
+    agent,
+    *,
+    goal: TestGoal,
+    dom_elements: List[DOMElement],
+) -> Optional[str]:
+    if not _goal_requests_payment_presubmit(agent, goal):
+        return None
+    if not dom_elements:
+        return None
+
+    visible_blobs: List[str] = []
+    payment_cta_blobs: List[str] = []
+    for el in list(dom_elements or [])[:220]:
+        if not bool(getattr(el, "is_visible", True)):
+            continue
+        blob = _payment_presubmit_blob(agent, el)
+        if not blob:
+            continue
+        visible_blobs.append(blob)
+        role = agent._normalize_text(getattr(el, "role", ""))
+        tag = agent._normalize_text(getattr(el, "tag", ""))
+        actionable = bool(getattr(el, "is_enabled", True)) and (
+            role in {"button", "link"} or tag in {"button", "a", "input"}
+        )
+        if actionable and any(
+            token in blob
+            for token in (
+                "결제하기",
+                "결제 하기",
+                "결제 버튼",
+                "pay now",
+                "make payment",
+                "submit payment",
+            )
+        ):
+            payment_cta_blobs.append(blob)
+
+    if not visible_blobs or not payment_cta_blobs:
+        return None
+    page_blob = " ".join(visible_blobs)
+    post_payment_tokens = (
+        "결제 완료",
+        "결제가 완료",
+        "주문 완료",
+        "구매 완료",
+        "결제 성공",
+        "영수증",
+        "receipt",
+        "payment complete",
+        "order complete",
+        "thank you for your order",
+    )
+    if any(token in page_blob for token in post_payment_tokens):
+        return None
+    checkout_surface_tokens = (
+        "주문/결제",
+        "주문 결제",
+        "주문서",
+        "주문 확인",
+        "네이버페이 주문",
+        "결제수단",
+        "결제 수단",
+        "배송지",
+        "배송 정보",
+        "주문상품",
+        "주문 상품",
+        "총 결제",
+        "결제금액",
+        "결제 금액",
+        "최종 결제",
+        "checkout",
+        "payment method",
+        "shipping",
+        "billing",
+        "order summary",
+        "order total",
+    )
+    if not any(token in page_blob for token in checkout_surface_tokens):
+        return None
+    return "최종 결제 실행 버튼이 보이는 주문/결제 화면에 도달해 결제 직전 상태로 목표를 완료로 판정했습니다."
+
+
 def evaluate_readonly_visibility_completion(
     agent,
     *,
@@ -506,6 +664,13 @@ def evaluate_goal_target_completion(
     policy_reason = agent._run_goal_policy_closer(goal=goal, dom_elements=dom_elements)
     if policy_reason:
         return policy_reason
+    payment_presubmit_reason = evaluate_payment_presubmit_completion(
+        agent,
+        goal=goal,
+        dom_elements=dom_elements,
+    )
+    if payment_presubmit_reason:
+        return payment_presubmit_reason
     if is_readonly_visibility_goal(agent, goal):
         return None
     if requires_explicit_submission_completion(agent, goal):

--- a/gaia/src/phase4/mcp_openclaw_dispatch_runtime.py
+++ b/gaia/src/phase4/mcp_openclaw_dispatch_runtime.py
@@ -7,7 +7,7 @@ import re
 import threading
 import time
 from typing import Any, Dict, List, Optional, Tuple
-from urllib.parse import urlparse, urlunparse
+from urllib.parse import quote, urlparse, urlunparse
 
 import requests
 
@@ -326,6 +326,10 @@ def _normalize_url(url: str | None) -> str:
     return str(url or "").strip()
 
 
+def _is_about_blank_url(url: str | None) -> bool:
+    return _normalize_url(url).lower() == "about:blank"
+
+
 def _session_state(session_id: str) -> Dict[str, Any]:
     with _SESSION_LOCK:
         return _SESSIONS.setdefault(
@@ -442,6 +446,90 @@ def _target_missing(status_code: int, data: Dict[str, Any], text: str) -> bool:
     )
 
 
+def _choose_existing_tab(
+    payload: Optional[Dict[str, Any]],
+    *,
+    allow_about_blank: bool = False,
+) -> Optional[Dict[str, Any]]:
+    descriptors = _extract_tab_descriptors(payload)
+    if not descriptors:
+        return None
+    candidates = [
+        item
+        for item in descriptors
+        if str(item.get("target_id") or "").strip()
+        and (allow_about_blank or not _is_about_blank_url(str(item.get("url") or "")))
+    ]
+    if not candidates:
+        return None
+    active = [item for item in candidates if bool(item.get("active"))]
+    return active[0] if active else candidates[0]
+
+
+def _adopt_existing_target(
+    *,
+    base_url: str,
+    state: Dict[str, Any],
+    profile: str,
+    timeout: Any,
+) -> bool:
+    tabs_payload = _tabs_payload_for_target(
+        base_url=base_url,
+        target_id="",
+        profile=profile,
+        timeout=timeout,
+    )
+    chosen = _choose_existing_tab(tabs_payload, allow_about_blank=False)
+    if not chosen:
+        return False
+    target_id = str(chosen.get("target_id") or "").strip()
+    current_url = _normalize_url(str(chosen.get("url") or ""))
+    if not target_id:
+        return False
+    state["target_id"] = target_id
+    state["current_url"] = current_url
+    _clear_snapshot_cache(state)
+    _clear_tabs_cache(state)
+    return True
+
+
+def _cleanup_about_blank_tabs(
+    *,
+    base_url: str,
+    profile: str,
+    timeout: Any,
+    keep_target_id: str = "",
+) -> None:
+    try:
+        tabs_payload = _tabs_payload_for_target(
+            base_url=base_url,
+            target_id=str(keep_target_id or "").strip(),
+            profile=profile,
+            timeout=timeout,
+        )
+    except Exception:
+        return
+    descriptors = _extract_tab_descriptors(tabs_payload)
+    if not any(not _is_about_blank_url(str(item.get("url") or "")) for item in descriptors):
+        return
+    for item in descriptors:
+        target_id = str(item.get("target_id") or "").strip()
+        if not target_id or target_id == str(keep_target_id or "").strip():
+            continue
+        if not _is_about_blank_url(str(item.get("url") or "")):
+            continue
+        try:
+            _request(
+                "DELETE",
+                base_url=base_url,
+                path=f"/tabs/{quote(target_id, safe='')}",
+                timeout=timeout,
+                params={"profile": profile},
+            )
+        except Exception:
+            pass
+
+
 def _ensure_target(
     *,
     base_url: str,
@@ -456,7 +544,31 @@ def _ensure_target(
     normalized_requested = _normalize_url(requested_url)
 
     if not target_id:
-        open_url = normalized_requested or current_url or "about:blank"
+        open_url = normalized_requested or ("" if _is_about_blank_url(current_url) else current_url)
+        if not open_url:
+            try:
+                adopted_existing_target = _adopt_existing_target(
+                    base_url=base_url,
+                    state=state,
+                    profile=profile,
+                    timeout=timeout,
+                )
+            except Exception:
+                adopted_existing_target = False
+            if adopted_existing_target:
+                _cleanup_about_blank_tabs(
+                    base_url=base_url,
+                    profile=profile,
+                    timeout=timeout,
+                    keep_target_id=str(state.get("target_id") or "").strip(),
+                )
+                return state
+            _cleanup_about_blank_tabs(
+                base_url=base_url,
+                profile=profile,
+                timeout=timeout,
+            )
+            return state
         status_code, data, text = _request(
             "POST",
             base_url=base_url,
@@ -474,6 +586,13 @@ def _ensure_target(
         _clear_snapshot_cache(state)
         _clear_tabs_cache(state)
         current_url = str(state.get("current_url") or "")
+        if not _is_about_blank_url(current_url):
+            _cleanup_about_blank_tabs(
+                base_url=base_url,
+                profile=profile,
+                timeout=timeout,
+                keep_target_id=target_id,
+            )
 
     if normalized_requested and normalized_requested != current_url:
         status_code, data, text = _request(
@@ -498,6 +617,13 @@ def _ensure_target(
         state["current_url"] = _normalize_url(data.get("url") or normalized_requested)
         _clear_snapshot_cache(state)
         _clear_tabs_cache(state)
+        if not _is_about_blank_url(str(state.get("current_url") or "")):
+            _cleanup_about_blank_tabs(
+                base_url=base_url,
+                profile=profile,
+                timeout=timeout,
+                keep_target_id=target_id,
+            )
 
     return state
 

--- a/gaia/terminal.py
+++ b/gaia/terminal.py
@@ -8,6 +8,18 @@ import time
 from typing import Any, Callable, Dict, Optional, Sequence, Tuple
 
 from gaia.src.phase4.goal_driven import ExplorationConfig, ExploratoryAgent, GoalDrivenAgent, TestGoal
+from gaia.src.phase4.goal_driven.adaptive_qa_runtime import (
+    ADAPTIVE_QA_MODE,
+    DEEP_ADAPTIVE_QA_MODE,
+    adaptive_qa_enabled,
+    adaptive_qa_is_deep,
+    adaptive_qa_mode,
+    build_edge_goal,
+    filter_new_edge_cases,
+    generate_adaptive_qa_plan,
+    merge_adaptive_qa_plans,
+    summarize_adaptive_qa_report,
+)
 from gaia.src.phase4.goal_driven.multi_user_interaction_runtime import close_participant_browser_contexts
 from gaia.src.phase4.goal_driven.goal_verification_helpers import derive_achieved_signals
 from gaia.src.phase4.goal_driven.site_auth_store import load_site_credentials
@@ -29,6 +41,11 @@ def _extract_inline_test_data(query: str) -> tuple[str, Dict[str, str]]:
         "email": "email",
         "pw": "password",
         "password": "password",
+        "qa_mode": "qa_mode",
+        "mode": "qa_mode",
+        "adaptive_qa": ADAPTIVE_QA_MODE,
+        "deep_adaptive_qa": DEEP_ADAPTIVE_QA_MODE,
+        "deep_qa": DEEP_ADAPTIVE_QA_MODE,
     }
     for tok in tokens:
         if "=" not in tok:
@@ -56,6 +73,19 @@ def _build_test_goal(url: str, query: str) -> TestGoal:
     except Exception:
         max_steps = 20
     max_steps = max(1, max_steps)
+    if str(os.getenv("GAIA_ADAPTIVE_QA", "") or "").strip().lower() in {"1", "true", "yes", "on"}:
+        inline_data.setdefault(ADAPTIVE_QA_MODE, {"enabled": True})
+    if str(os.getenv("GAIA_DEEP_ADAPTIVE_QA", "") or "").strip().lower() in {"1", "true", "yes", "on"}:
+        inline_data.setdefault(DEEP_ADAPTIVE_QA_MODE, {"enabled": True})
+    qa_mode = str(inline_data.get("qa_mode") or "").strip().lower()
+    if qa_mode in {"deep", "deep_qa", "aggressive_qa", DEEP_ADAPTIVE_QA_MODE}:
+        inline_data.setdefault(DEEP_ADAPTIVE_QA_MODE, {"enabled": True})
+    if qa_mode in {"adaptive", ADAPTIVE_QA_MODE, "progressive_qa"}:
+        inline_data.setdefault(ADAPTIVE_QA_MODE, {"enabled": True})
+    if str(inline_data.get(ADAPTIVE_QA_MODE) or "").strip().lower() in {"1", "true", "yes", "on"}:
+        inline_data[ADAPTIVE_QA_MODE] = {"enabled": True}
+    if str(inline_data.get(DEEP_ADAPTIVE_QA_MODE) or "").strip().lower() in {"1", "true", "yes", "on"}:
+        inline_data[DEEP_ADAPTIVE_QA_MODE] = {"enabled": True}
     return TestGoal(
         id=f"CHAT_{ts}",
         name=(query_text[:40] or "chat test").strip(),
@@ -716,6 +746,64 @@ def _run_single_chat_goal(
         if not effective_success:
             _print_llm_failure_help(effective_reason)
 
+        adaptive_qa_report: Dict[str, Any] | None = None
+        if adaptive_qa_enabled(goal):
+            qa_mode_label = adaptive_qa_mode(goal) or ADAPTIVE_QA_MODE
+            print(f"\n🧪 {qa_mode_label} 확장 모드")
+            adaptive_primary_result = result.model_copy(
+                update={"success": bool(effective_success), "final_reason": effective_reason}
+            )
+            is_deep_qa = adaptive_qa_is_deep(goal)
+            plans: list[Dict[str, Any]] = []
+            generated_edge_cases: list[Dict[str, Any]] = []
+            seen_edge_fingerprints: set[str] = set()
+            edge_results: list[Dict[str, Any]] = []
+            round_index = 1
+            while True:
+                current_dom = agent._analyze_dom() or []
+                plan = generate_adaptive_qa_plan(
+                    agent,
+                    goal=goal,
+                    primary_result=adaptive_primary_result,
+                    dom_elements=current_dom,
+                    previous_edge_cases=generated_edge_cases,
+                    round_index=round_index,
+                )
+                plans.append(plan)
+                raw_edge_cases = list(plan.get("edge_cases") or []) if isinstance(plan, dict) else []
+                edge_cases = filter_new_edge_cases(raw_edge_cases, seen_edge_fingerprints)
+                if not edge_cases or not adaptive_primary_result.success:
+                    print("   새로 실행할 안전 엣지 케이스가 없습니다.")
+                    break
+                print(f"   round {round_index}: 안전 엣지 케이스 {len(edge_cases)}개 실행")
+                for edge_case in edge_cases:
+                    generated_edge_cases.append(edge_case)
+                    edge_goal = build_edge_goal(goal, edge_case, index=len(edge_results) + 1)
+                    print(f"   [{len(edge_results) + 1}] {edge_goal.name}")
+                    edge_result = agent.execute_goal(edge_goal)
+                    edge_status = "PASS" if edge_result.success else "FAIL"
+                    edge_results.append(
+                        {
+                            "id": edge_goal.id,
+                            "name": edge_goal.name,
+                            "status": edge_status,
+                            "reason": edge_result.final_reason,
+                            "steps": edge_result.total_steps,
+                        }
+                    )
+                    print(f"      {edge_status}: {edge_result.final_reason}")
+                if not is_deep_qa:
+                    break
+                round_index += 1
+            merged_plan = merge_adaptive_qa_plans(plans)
+            merged_plan["edge_cases"] = generated_edge_cases
+            adaptive_qa_report = summarize_adaptive_qa_report(
+                primary_goal=goal,
+                primary_result=adaptive_primary_result,
+                plan=merged_plan,
+                edge_results=edge_results,
+            )
+
         expected_signals = [
             str(item or "").strip().lower()
             for item in list(getattr(goal, "expected_signals", []) or [])
@@ -771,6 +859,8 @@ def _run_single_chat_goal(
             "validation_rail_artifacts": rail_artifacts,
             "attachments": summary_attachments,
         }
+        if adaptive_qa_report is not None:
+            summary["adaptive_qa_report"] = adaptive_qa_report
         if isinstance(evidence_attachment, dict) and evidence_attachment.get("kind") == "evidence_capture_error":
             summary["evidence_capture_error"] = str(evidence_attachment.get("reason") or "")
         summary["attachments"] = _limit_attachments_for_status(

--- a/gaia/tests/unit/test_adaptive_qa_runtime.py
+++ b/gaia/tests/unit/test_adaptive_qa_runtime.py
@@ -1,0 +1,234 @@
+from __future__ import annotations
+
+import json
+
+from gaia.src.phase4.goal_driven.adaptive_qa_runtime import (
+    ADAPTIVE_QA_MODE,
+    DEEP_ADAPTIVE_QA_MODE,
+    adaptive_qa_enabled,
+    adaptive_qa_mode,
+    build_edge_goal,
+    generate_adaptive_qa_plan,
+    summarize_adaptive_qa_report,
+)
+from gaia.src.phase4.goal_driven.models import DOMElement, GoalResult, TestGoal as GoalModel
+
+
+class _AdaptiveAgent:
+    def __init__(self, payload: dict) -> None:
+        self._payload = payload
+        self._last_prompt = ""
+        self._action_history = ["click 스포츠 필터", "click 축구 카테고리"]
+        self._action_feedback = ["축구 뉴스 목록이 표시됨"]
+
+    def _call_llm_text_only(self, prompt: str) -> str:
+        self._last_prompt = prompt
+        return "```json\n" + json.dumps(self._payload, ensure_ascii=False) + "\n```"
+
+    @staticmethod
+    def _format_dom_for_llm(elements: list[DOMElement]) -> str:
+        return "\n".join(str(item.text or item.aria_label or "") for item in elements)
+
+
+def _goal(test_data: dict | None = None) -> GoalModel:
+    return GoalModel(
+        id="G1",
+        name="뉴스 축구 순위 확인",
+        description="네이버 뉴스에서 스포츠 필터와 축구 카테고리를 선택한 뒤 상위 3개 팀 순위를 확인한다.",
+        priority="MUST",
+        test_data=test_data or {},
+        success_criteria=["상위 3개 팀 순위가 보인다."],
+        max_steps=20,
+        start_url="https://news.naver.com/",
+    )
+
+
+def _result(success: bool = True) -> GoalResult:
+    return GoalResult(
+        goal_id="G1",
+        goal_name="뉴스 축구 순위 확인",
+        success=success,
+        total_steps=4,
+        final_reason="상위 3개 팀 순위가 화면에 표시됨" if success else "축구 카테고리 진입 실패",
+    )
+
+
+def test_adaptive_qa_enabled_from_explicit_config_and_mode_alias() -> None:
+    assert adaptive_qa_enabled(_goal({ADAPTIVE_QA_MODE: {"enabled": True}})) is True
+    assert adaptive_qa_enabled(_goal({"qa_mode": "progressive_qa"})) is True
+    assert adaptive_qa_enabled(_goal({ADAPTIVE_QA_MODE: {"enabled": False}})) is False
+    assert adaptive_qa_mode(_goal({DEEP_ADAPTIVE_QA_MODE: {"enabled": True}})) == DEEP_ADAPTIVE_QA_MODE
+    assert adaptive_qa_mode(_goal({"qa_mode": "deep_qa"})) == DEEP_ADAPTIVE_QA_MODE
+
+
+def test_generate_plan_parses_checks_and_filters_risky_edges() -> None:
+    agent = _AdaptiveAgent(
+        {
+            "checks": [
+                {
+                    "id": "top_three_visible",
+                    "title": "상위 3개 팀 노출",
+                    "rationale": "사용자 목표의 핵심 검증이다.",
+                    "evidence_hint": "순위표 첫 3행",
+                }
+            ],
+            "edge_cases": [
+                {
+                    "id": "switch_sort",
+                    "name": "정렬 전환 반영",
+                    "description": "현재 순위 영역에서 다른 정렬 옵션을 선택해 목록이 갱신되는지 확인한다.",
+                    "reason": "관찰 가능한 필터 확장",
+                    "success_criteria": ["정렬 선택값과 목록 표시가 일치한다."],
+                },
+                {
+                    "id": "paid_checkout",
+                    "name": "결제 버튼 확인",
+                    "description": "유료 결제 버튼을 눌러 결제 완료 상태까지 진행한다.",
+                    "reason": "결제는 비용 발생 위험이 있다.",
+                    "success_criteria": ["결제 완료"],
+                },
+                {
+                    "id": "category_back",
+                    "name": "카테고리 되돌림",
+                    "description": "다른 축구 하위 카테고리를 선택했다가 원래 카테고리로 돌아와 순위표가 유지되는지 확인한다.",
+                    "success_criteria": ["순위표가 다시 표시된다."],
+                },
+            ],
+        }
+    )
+    dom = [DOMElement(id=1, tag="section", text="축구 순위표 1위 2위 3위")]
+
+    plan = generate_adaptive_qa_plan(
+        agent,
+        goal=_goal({ADAPTIVE_QA_MODE: {"enabled": True, "max_edge_cases": 2}}),
+        primary_result=_result(True),
+        dom_elements=dom,
+    )
+
+    assert plan["status"] == "generated"
+    assert [item["id"] for item in plan["checks"]] == ["top_three_visible"]
+    assert [item["id"] for item in plan["edge_cases"]] == ["switch_sort", "category_back"]
+    assert "현재 DOM" in agent._last_prompt
+
+
+def test_generate_plan_allows_user_authorized_message_send_edge() -> None:
+    agent = _AdaptiveAgent(
+        {
+            "checks": [{"id": "mail_sent_visible", "title": "메일 전송 결과 확인"}],
+            "edge_cases": [
+                {
+                    "id": "send_test_mail",
+                    "name": "메일 전송 확인",
+                    "description": "사용자가 지정한 수신자에게 지정한 테스트 문구를 메일로 전송하고 전송 완료 문구가 보이는지 확인한다.",
+                    "reason": "사용자가 메일 전송을 명시적으로 허용했다.",
+                    "safety": "user_authorized_reversible_enough",
+                    "success_criteria": ["전송 완료 문구가 보인다."],
+                }
+            ],
+        }
+    )
+
+    plan = generate_adaptive_qa_plan(
+        agent,
+        goal=_goal({ADAPTIVE_QA_MODE: {"enabled": True, "max_edge_cases": 2}}),
+        primary_result=_result(True),
+        dom_elements=[],
+    )
+
+    assert [item["id"] for item in plan["edge_cases"]] == ["send_test_mail"]
+
+
+def test_deep_adaptive_qa_generates_more_edge_cases_with_aggressive_prompt() -> None:
+    agent = _AdaptiveAgent(
+        {
+            "checks": [{"id": "rank_table", "title": "순위표 표시"}],
+            "edge_cases": [
+                {
+                    "id": f"safe_edge_{idx}",
+                    "name": f"안전 엣지 {idx}",
+                    "description": f"현재 화면에서 안전한 필터 전환 {idx}을 확인한다.",
+                    "success_criteria": ["화면 증거가 보인다."],
+                }
+                for idx in range(1, 7)
+            ],
+        }
+    )
+
+    plan = generate_adaptive_qa_plan(
+        agent,
+        goal=_goal({DEEP_ADAPTIVE_QA_MODE: {"enabled": True}}),
+        primary_result=_result(True),
+        dom_elements=[],
+    )
+
+    assert plan["mode"] == DEEP_ADAPTIVE_QA_MODE
+    assert len(plan["edge_cases"]) == 6
+    assert "공격적 Deep QA 모드" in agent._last_prompt
+
+
+def test_generate_plan_does_not_execute_edges_when_primary_failed() -> None:
+    agent = _AdaptiveAgent(
+        {
+            "checks": [{"id": "sports_filter", "title": "스포츠 필터 진입"}],
+            "edge_cases": [
+                {
+                    "id": "safe_filter",
+                    "name": "필터 변경",
+                    "description": "다른 필터를 선택해 상태 변화를 확인한다.",
+                }
+            ],
+        }
+    )
+
+    plan = generate_adaptive_qa_plan(
+        agent,
+        goal=_goal({ADAPTIVE_QA_MODE: {"enabled": True}}),
+        primary_result=_result(False),
+        dom_elements=[],
+    )
+
+    assert plan["checks"][0]["id"] == "sports_filter"
+    assert plan["edge_cases"] == []
+
+
+def test_build_edge_goal_continues_current_page_and_disables_recursive_expansion() -> None:
+    parent = _goal(
+        {
+            ADAPTIVE_QA_MODE: {"enabled": True},
+            DEEP_ADAPTIVE_QA_MODE: {"enabled": True},
+            "qa_mode": DEEP_ADAPTIVE_QA_MODE,
+            "keep": "value",
+        }
+    )
+    edge_goal = build_edge_goal(
+        parent,
+        {
+            "name": "정렬 전환 반영",
+            "description": "현재 순위 영역에서 다른 정렬 옵션을 선택해 목록이 갱신되는지 확인한다.",
+            "success_criteria": ["목록이 갱신된다."],
+        },
+        index=1,
+    )
+
+    assert edge_goal.id == "G1_EDGE_1"
+    assert edge_goal.start_url is None
+    assert edge_goal.max_steps == 8
+    assert edge_goal.test_data["keep"] == "value"
+    assert ADAPTIVE_QA_MODE not in edge_goal.test_data
+    assert DEEP_ADAPTIVE_QA_MODE not in edge_goal.test_data
+    assert "qa_mode" not in edge_goal.test_data
+    assert edge_goal.test_data["adaptive_qa_edge_case"] is True
+
+
+def test_summary_scores_primary_and_edge_results() -> None:
+    report = summarize_adaptive_qa_report(
+        primary_goal=_goal(),
+        primary_result=_result(True),
+        plan={"checks": [{"id": "extra", "title": "추가 체크"}], "edge_cases": [{"id": "edge"}]},
+        edge_results=[{"status": "PASS"}, {"status": "FAIL"}],
+    )
+
+    assert report["mode"] == ADAPTIVE_QA_MODE
+    assert report["summary"]["generated_check_count"] == 1
+    assert report["summary"]["executed_edge_case_count"] == 2
+    assert report["summary"]["score"] == 0.667

--- a/gaia/tests/unit/test_cli_adaptive_qa_mode.py
+++ b/gaia/tests/unit/test_cli_adaptive_qa_mode.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+from gaia.cli import (
+    DEEP_ADAPTIVE_QA_MODE,
+    QUICK_DEEP_QA_LABEL,
+    QUICK_RUN_MODE_CHOICES,
+    _dispatch_chat,
+    run_launcher,
+)
+
+
+class _TTY:
+    def isatty(self) -> bool:
+        return True
+
+
+def _stub_configured_terminal() -> tuple[str, str, str, str, str, str, str, bool]:
+    return (
+        "openai",
+        "gpt-5.5",
+        "reuse",
+        "https://example.com",
+        "terminal",
+        "workspace",
+        "session-1",
+        False,
+    )
+
+
+def test_launcher_interactive_menu_can_select_deep_qa(monkeypatch) -> None:
+    profile: dict[str, str] = {}
+    captured: dict[str, object] = {}
+
+    monkeypatch.setattr("gaia.cli._configure_session", lambda parsed, require_url: _stub_configured_terminal())
+    monkeypatch.setattr("gaia.cli.load_session_state", lambda session_key: None)
+    monkeypatch.setattr("gaia.cli._load_profile", lambda: profile)
+    monkeypatch.setattr("gaia.cli._resolve_terminal_launch_purpose", lambda *args, **kwargs: "actual")
+    monkeypatch.setattr("gaia.cli._resolve_url", lambda *args, **kwargs: "https://example.com")
+    monkeypatch.setattr("gaia.cli._persist_session_state", lambda **kwargs: None)
+    monkeypatch.setattr("gaia.cli._persist_profile", lambda profile, **kwargs: None)
+    monkeypatch.setattr("gaia.cli._resolve_control_channel", lambda *args, **kwargs: "local")
+    monkeypatch.setattr("gaia.cli.sys.stdin", _TTY())
+
+    def fake_select(prompt: str, options, default=None):
+        captured["prompt"] = prompt
+        captured["options"] = tuple(options)
+        captured["default"] = default
+        return QUICK_DEEP_QA_LABEL
+
+    def fake_dispatch_chat(runtime, url, feature_query, repl, *, session_id, qa_mode=None):
+        captured["runtime"] = runtime
+        captured["url"] = url
+        captured["feature_query"] = feature_query
+        captured["repl"] = repl
+        captured["session_id"] = session_id
+        captured["qa_mode"] = qa_mode
+        return 0
+
+    monkeypatch.setattr("gaia.cli._prompt_select", fake_select)
+    monkeypatch.setattr("gaia.cli._prompt_non_empty", lambda prompt: "네이버 쇼핑에서 배송 필터 검증")
+    monkeypatch.setattr("gaia.cli._dispatch_chat", fake_dispatch_chat)
+
+    assert run_launcher(["--terminal"]) == 0
+
+    assert captured["prompt"] == "실행 방식을 선택하세요"
+    assert captured["options"] == QUICK_RUN_MODE_CHOICES
+    assert captured["qa_mode"] == DEEP_ADAPTIVE_QA_MODE
+    assert captured["feature_query"] == "네이버 쇼핑에서 배송 필터 검증"
+    assert captured["repl"] is False
+    assert profile["last_quick_mode"] == DEEP_ADAPTIVE_QA_MODE
+
+
+def test_dispatch_chat_terminal_applies_deep_qa_env_for_run(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+    monkeypatch.setenv("GAIA_ADAPTIVE_QA", "old-adaptive")
+    monkeypatch.delenv("GAIA_DEEP_ADAPTIVE_QA", raising=False)
+
+    def fake_terminal_runner(*, url, initial_query, repl, session_id):
+        import os
+
+        captured["url"] = url
+        captured["initial_query"] = initial_query
+        captured["repl"] = repl
+        captured["session_id"] = session_id
+        captured["adaptive_env"] = os.environ.get("GAIA_ADAPTIVE_QA")
+        captured["deep_env"] = os.environ.get("GAIA_DEEP_ADAPTIVE_QA")
+        return 17
+
+    monkeypatch.setattr("gaia.terminal.run_chat_terminal", fake_terminal_runner)
+
+    result = _dispatch_chat(
+        "terminal",
+        "https://example.com",
+        "목표 실행",
+        False,
+        session_id="session-1",
+        qa_mode=DEEP_ADAPTIVE_QA_MODE,
+    )
+
+    assert result == 17
+    assert captured["adaptive_env"] is None
+    assert captured["deep_env"] == "1"
+    import os
+
+    assert os.environ.get("GAIA_ADAPTIVE_QA") == "old-adaptive"
+    assert os.environ.get("GAIA_DEEP_ADAPTIVE_QA") is None
+
+
+def test_dispatch_chat_gui_forwards_deep_qa_mode(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_run_gui(argv):
+        captured["argv"] = list(argv)
+        return 0
+
+    monkeypatch.setattr("gaia.cli.run_gui", fake_run_gui)
+
+    assert (
+        _dispatch_chat(
+            "gui",
+            "https://example.com",
+            "목표 실행",
+            False,
+            session_id="session-1",
+            qa_mode=DEEP_ADAPTIVE_QA_MODE,
+        )
+        == 0
+    )
+
+    assert captured["argv"] == [
+        "--mode",
+        DEEP_ADAPTIVE_QA_MODE,
+        "--url",
+        "https://example.com",
+        "--feature-query",
+        "목표 실행",
+    ]

--- a/gaia/tests/unit/test_goal_achievement_runtime.py
+++ b/gaia/tests/unit/test_goal_achievement_runtime.py
@@ -4,6 +4,8 @@ from types import SimpleNamespace
 
 from gaia.src.phase4.goal_driven.goal_achievement_runtime import validate_goal_achievement_claim
 from gaia.src.phase4.goal_driven.goal_completion_helpers import (
+    evaluate_goal_target_completion,
+    evaluate_payment_presubmit_completion,
     evaluate_reasoning_only_wait_completion,
     evaluate_wait_goal_completion,
 )
@@ -104,6 +106,109 @@ def test_validate_goal_achievement_claim_accepts_wait_when_destination_row_is_vi
 
     assert ok is True
     assert reason is None
+
+
+def test_payment_presubmit_completion_accepts_checkout_page_with_final_payment_cta() -> None:
+    agent = _FakeAgent()
+    agent._goal_constraints = {}
+    goal = SimpleNamespace(
+        name="결제 직전까지 검증",
+        description="상품을 장바구니에 담고 결제하기를 누르기 전 화면까지 도달한다.",
+        success_criteria=["주문/결제 화면에서 결제하기 버튼이 보이는지 확인"],
+    )
+    dom = [
+        DOMElement(
+            id=1,
+            tag="h1",
+            role="heading",
+            text="네이버페이 주문/결제",
+            is_visible=True,
+        ),
+        DOMElement(
+            id=2,
+            tag="section",
+            role="region",
+            text="배송지 결제수단 총 결제금액 49,000원",
+            context_text="주문상품 배송 정보 결제 수단",
+            is_visible=True,
+        ),
+        DOMElement(
+            id=3,
+            tag="button",
+            role="button",
+            text="결제하기",
+            context_text="최종 결제 실행",
+            is_visible=True,
+            is_enabled=True,
+        ),
+    ]
+
+    reason = evaluate_payment_presubmit_completion(agent, goal=goal, dom_elements=dom)
+
+    assert reason is not None
+    assert "결제 직전" in reason
+    assert evaluate_goal_target_completion(agent, goal=goal, dom_elements=dom) == reason
+
+
+def test_payment_presubmit_completion_rejects_cart_order_cta_before_checkout() -> None:
+    agent = _FakeAgent()
+    agent._goal_constraints = {}
+    goal = SimpleNamespace(
+        name="결제 직전까지 검증",
+        description="장바구니에서 결제하기 직전 화면까지 도달한다.",
+        success_criteria=["결제하기 버튼이 보이는 주문/결제 화면"],
+    )
+    dom = [
+        DOMElement(
+            id=1,
+            tag="h1",
+            role="heading",
+            text="장바구니",
+            context_text="총 주문 예상 금액 49,000원",
+            is_visible=True,
+        ),
+        DOMElement(
+            id=2,
+            tag="button",
+            role="button",
+            text="주문하기 1개의 상품",
+            context_text="장바구니 하단 버튼",
+            is_visible=True,
+            is_enabled=True,
+        ),
+    ]
+
+    assert evaluate_payment_presubmit_completion(agent, goal=goal, dom_elements=dom) is None
+
+
+def test_payment_presubmit_completion_rejects_payment_completion_goal() -> None:
+    agent = _FakeAgent()
+    agent._goal_constraints = {}
+    goal = SimpleNamespace(
+        name="결제 완료까지 진행",
+        description="결제 버튼을 눌러 결제 완료 상태까지 진행한다.",
+        success_criteria=["결제 완료"],
+    )
+    dom = [
+        DOMElement(
+            id=1,
+            tag="h1",
+            role="heading",
+            text="주문/결제",
+            context_text="배송지 결제수단 총 결제금액",
+            is_visible=True,
+        ),
+        DOMElement(
+            id=2,
+            tag="button",
+            role="button",
+            text="결제하기",
+            is_visible=True,
+            is_enabled=True,
+        ),
+    ]
+
+    assert evaluate_payment_presubmit_completion(agent, goal=goal, dom_elements=dom) is None
 
 
 def test_validate_goal_achievement_claim_accepts_wait_when_destination_anchor_and_row_action_are_separate():

--- a/gaia/tests/unit/test_goal_completion_helpers.py
+++ b/gaia/tests/unit/test_goal_completion_helpers.py
@@ -139,6 +139,59 @@ def test_goal_constraints_do_not_promote_ranking_counts_to_collect_min() -> None
     assert constraints.get("metric_label") is None
 
 
+def test_goal_constraints_ignore_forbidden_purchase_or_cart_actions() -> None:
+    goal = TestGoal(
+        id="shopping-readonly",
+        name="네이버 쇼핑 검색 결과 검증",
+        description=(
+            "네이버에 로그인한 상태에서 네이버 쇼핑으로 이동해 '노트북 파우치 13인치'를 검색한다. "
+            "검색 결과에서 필터 또는 정렬 affordance를 활용해 결과가 바뀌는지 확인하고, "
+            "상위 3개 상품 카드의 상품명, 가격, 판매처 또는 배송 정보가 정상 표시되는지 검증한다. "
+            "장바구니 담기, 구매, 결제, 유료 예약, 개인정보 변경은 절대 하지 마."
+        ),
+        success_criteria=[
+            "상위 3개 상품 카드의 상품명, 가격, 판매처 또는 배송 정보가 표시된다.",
+        ],
+    )
+
+    constraints = GoalDrivenAgent._derive_goal_constraints(goal)
+
+    assert constraints.get("mutation_direction") is None
+    assert "네이버에" not in constraints.get("target_terms", [])
+
+
+def test_goal_target_completion_skips_filter_control_visibility_shortcut() -> None:
+    agent = _CompletionAgent()
+    agent._goal_target_terms = lambda goal: ["N배송 빠르게 받기", "빠른배송 전체"]  # type: ignore[method-assign]
+    goal = TestGoal(
+        id="shipping-filter-edge",
+        name="N배송/빠른배송 필터 검증",
+        description=(
+            "화면에 보이는 'N배송 빠르게 받기' 또는 '빠른배송 전체' 버튼을 선택해 "
+            "결과가 배송 유형 기준으로 바뀌는지 확인하고, 상위 상품 카드에 배송 정보가 표시되는지 검증한다."
+        ),
+        success_criteria=[
+            "배송유형 필터 선택 상태가 보인다.",
+            "상위 카드에 빠른배송/N배송/오늘출발/도착 예정 중 하나가 표시된다.",
+        ],
+    )
+    dom = [
+        DOMElement(
+            id=1,
+            tag="button",
+            role="button",
+            text="N배송 빠르게 받기",
+            context_text="배송 필터",
+            is_visible=True,
+            is_enabled=True,
+        )
+    ]
+
+    reason = evaluate_goal_target_completion(agent, goal=goal, dom_elements=dom)
+
+    assert reason is None
+
+
 def test_goal_target_completion_skips_explicit_mail_send_submission_shortcut() -> None:
     agent = _CompletionAgent()
     agent._goal_constraints = {

--- a/gaia/tests/unit/test_mcp_openclaw_dispatch_runtime.py
+++ b/gaia/tests/unit/test_mcp_openclaw_dispatch_runtime.py
@@ -271,6 +271,119 @@ def test_session_profile_change_invalidates_cached_snapshot() -> None:
     assert state["last_tabs_observed_at"] == 0.0
 
 
+def test_ensure_target_adopts_existing_non_blank_tab_and_cleans_blank_tabs(monkeypatch) -> None:
+    session_id = "adopt-existing-tab-s1"
+    state = _seed_session(session_id, target_id="", current_url="")
+    calls: list[tuple[str, str, dict[str, object], dict[str, object]]] = []
+
+    def fake_request(method, *, base_url, path, timeout=None, params=None, payload=None):
+        calls.append((method, path, dict(params or {}), dict(payload or {})))
+        if method == "GET" and path == "/tabs":
+            return (
+                200,
+                {
+                    "running": True,
+                    "tabs": [
+                        {"targetId": "blank-tab", "url": "about:blank"},
+                        {"targetId": "tab-1", "url": _DEFAULT_URL, "active": True},
+                    ],
+                },
+                "",
+            )
+        if method == "DELETE" and path == "/tabs/blank-tab":
+            return 200, {"ok": True}, ""
+        raise AssertionError((method, path, params, payload))
+
+    monkeypatch.setattr(runtime, "_request", fake_request)
+
+    result = runtime._ensure_target(
+        base_url="http://127.0.0.1:18791",
+        session_id=session_id,
+        requested_url="",
+        timeout=None,
+    )
+
+    assert result["target_id"] == "tab-1"
+    assert result["current_url"] == _DEFAULT_URL
+    assert not any(path == "/tabs/open" for _method, path, _params, _payload in calls)
+    assert ("DELETE", "/tabs/blank-tab", {"profile": "openclaw"}, {}) in calls
+    assert state["last_tabs_payload"] == {}
+
+
+def test_ensure_target_opens_requested_url_without_about_blank_and_cleans_blank_tabs(monkeypatch) -> None:
+    session_id = "open-real-url-s1"
+    state = _seed_session(session_id, target_id="", current_url="")
+    calls: list[tuple[str, str, dict[str, object], dict[str, object]]] = []
+
+    def fake_request(method, *, base_url, path, timeout=None, params=None, payload=None):
+        calls.append((method, path, dict(params or {}), dict(payload or {})))
+        if method == "POST" and path == "/tabs/open":
+            assert payload == {"url": _DEFAULT_URL, "profile": "openclaw"}
+            return 200, {"targetId": "tab-1", "url": _DEFAULT_URL}, ""
+        if method == "GET" and path == "/tabs":
+            return (
+                200,
+                {
+                    "running": True,
+                    "tabs": [
+                        {"targetId": "blank-tab", "url": "about:blank"},
+                        {"targetId": "tab-1", "url": _DEFAULT_URL, "active": True},
+                    ],
+                },
+                "",
+            )
+        if method == "DELETE" and path == "/tabs/blank-tab":
+            return 200, {"ok": True}, ""
+        raise AssertionError((method, path, params, payload))
+
+    monkeypatch.setattr(runtime, "_request", fake_request)
+
+    result = runtime._ensure_target(
+        base_url="http://127.0.0.1:18791",
+        session_id=session_id,
+        requested_url=_DEFAULT_URL,
+        timeout=None,
+    )
+
+    assert result["target_id"] == "tab-1"
+    assert result["current_url"] == _DEFAULT_URL
+    open_payloads = [payload for _method, path, _params, payload in calls if path == "/tabs/open"]
+    assert open_payloads == [{"url": _DEFAULT_URL, "profile": "openclaw"}]
+    assert all(payload.get("url") != "about:blank" for payload in open_payloads)
+    assert ("DELETE", "/tabs/blank-tab", {"profile": "openclaw"}, {}) in calls
+    assert state["last_tabs_payload"] == {}
+
+
+def test_ensure_target_does_not_open_about_blank_when_url_is_missing(monkeypatch) -> None:
+    session_id = "missing-url-s1"
+    state = _seed_session(session_id, target_id="", current_url="")
+    calls: list[tuple[str, str, dict[str, object], dict[str, object]]] = []
+
+    def fake_request(method, *, base_url, path, timeout=None, params=None, payload=None):
+        calls.append((method, path, dict(params or {}), dict(payload or {})))
+        if method == "GET" and path == "/tabs":
+            return (
+                200,
+                {"running": True, "tabs": [{"targetId": "blank-tab", "url": "about:blank"}]},
+                "",
+            )
+        raise AssertionError((method, path, params, payload))
+
+    monkeypatch.setattr(runtime, "_request", fake_request)
+
+    result = runtime._ensure_target(
+        base_url="http://127.0.0.1:18791",
+        session_id=session_id,
+        requested_url="",
+        timeout=None,
+    )
+
+    assert result["target_id"] == ""
+    assert result["current_url"] == ""
+    assert not any(path == "/tabs/open" for _method, path, _params, _payload in calls)
+    assert state["last_tabs_payload"] == {}
+
+
 def test_derive_state_change_from_snapshot_payloads_surfaces_new_page_evidence() -> None:
     before_payload = {
         "current_url": "https://cyber.inu.ac.kr/mod/page/view.php?id=123",


### PR DESCRIPTION
## Summary
- Add adaptive/deep QA expansion runtime that runs the user-requested primary goal first, then generates safe follow-up edge cases from observed evidence.
- Wire Adaptive QA and Deep QA into GUI, terminal execution, and the arrow-key `gaia.cli` launcher flow.
- Harden completion logic so forbidden purchase/cart clauses are not treated as intent and filter/sort goals require real state-change evidence.
- Add unit coverage for adaptive QA planning, CLI mode routing, and completion guard behavior.

## Why
Booth/demo usage needs GAIA to go beyond a single requested scenario and show QA-style expansion without requiring the user to pre-author every edge case. The default path stays unchanged; expansion only runs when explicitly selected.

## Validation
- `PYTHONPATH=. .venv/bin/python -m py_compile gaia/cli.py gaia/main.py gaia/terminal.py gaia/chat_hub.py gaia/auth.py gaia/src/gui/goal_worker.py`
- `PYTHONPATH=. .venv/bin/python -m pytest gaia/tests/unit/test_cli_adaptive_qa_mode.py gaia/tests/unit/test_adaptive_qa_runtime.py gaia/tests/unit/test_goal_completion_helpers.py -q` → 17 passed
- `PYTHONPATH=. .venv/bin/python -m pytest gaia/tests/unit/test_terminal_validation_gate.py gaia/tests/unit/test_terminal_session_cleanup.py gaia/tests/unit/test_terminal_benchmark_mode.py gaia/tests/unit/test_cli_adaptive_qa_mode.py -q` → 52 passed
- `python scripts/lint_harness_docs.py`
- `git diff --check`

## Known Existing Test Gap
- Full `PYTHONPATH=. .venv/bin/python -m pytest gaia/tests/unit -q` currently reports 512 passed / 3 failed in `gaia/tests/unit/test_gui_benchmark_sync.py`. These are pre-existing benchmark GUI failures observed before this PR scope.