### PR TITLE
Fix legacy goal completion human-answer reports

### DIFF
--- a/gaia/src/phase4/goal_driven/human_answer_runtime.py
+++ b/gaia/src/phase4/goal_driven/human_answer_runtime.py
@@ -91,6 +91,15 @@ def is_goal_achievement_confirmation_request(request: Mapping[str, Any]) -> bool
     if fields:
         return False
 
+    if reason_code in {
+        "goal_completed_report",
+        "goal_completion_report",
+        "goal_evidence_report",
+        "goal_achieved_report",
+        "goal_achievement_report",
+    }:
+        return True
+
     question = re.sub(r"\s+", " ", str(request.get("question") or "").strip().lower())
     if not question:
         return False

--- a/gaia/tests/unit/test_human_answer_runtime.py
+++ b/gaia/tests/unit/test_human_answer_runtime.py
@@ -85,6 +85,16 @@ def test_goal_achievement_confirmation_request_is_not_user_input() -> None:
     )
 
 
+def test_goal_completed_report_request_is_not_user_input() -> None:
+    assert is_goal_achievement_confirmation_request(
+        {
+            "question": "requests 프로젝트 화면에서 설치 명령과 최신 버전이 확인됩니다.",
+            "fields": [],
+            "reason_code": "goal_completed_report",
+        }
+    )
+
+
 def test_goal_achievement_confirmation_ignores_real_required_fields() -> None:
     assert not is_goal_achievement_confirmation_request(
         {


### PR DESCRIPTION
## Summary
- Treat legacy empty-field goal completion report payloads as goal verification requests instead of user input prompts.
- Add regression coverage for goal_completed_report.

## Verification
- .venv/bin/python -m pytest gaia/tests/unit/test_human_answer_runtime.py -q
- python scripts/lint_harness_docs.py
- headless PyPI package detail probe: SUCCESS (artifacts/tmp/legacy_human_answer_fix/pypi_package_detail)

Note: full unit suite on current main still has unrelated GUI benchmark sync failures; this change only touches goal-driven human_answer compatibility.