### PR TITLE
feat: OpenAI provider에 OPENAI_BASE_URL 환경변수 지원 추가

### DIFF
--- a/gaia/src/phase4/llm_vision_client.py
+++ b/gaia/src/phase4/llm_vision_client.py
@@ -28,7 +28,7 @@ class LLMVisionClient:
         "openai": {
             "api_key_env": "OPENAI_API_KEY",
             "base_url_env": "OPENAI_BASE_URL",
-            "model_env": "",
+            "model_env": "OPENAI_MODEL",
             "default_base_url": "",
             "default_model": "gpt-5.5",
             "display_name": "OpenAI",

--- a/gaia/src/phase4/llm_vision_client.py
+++ b/gaia/src/phase4/llm_vision_client.py
@@ -27,7 +27,7 @@ class LLMVisionClient:
     _OPENAI_COMPATIBLE_PROVIDER_CONFIG = {
         "openai": {
             "api_key_env": "OPENAI_API_KEY",
-            "base_url_env": "",
+            "base_url_env": "OPENAI_BASE_URL",
             "model_env": "",
             "default_base_url": "",
             "default_model": "gpt-5.5",


### PR DESCRIPTION
학교 MindLogic FactChat Cloud 게이트웨이 등 커스텀 OpenAI 호환
엔드포인트를 환경변수로 설정할 수 있도록 base_url_env 활성화.

- llm_vision_client.py: openai provider config의 base_url_env를 빈 문자열에서 OPENAI_BASE_URL로 변경
- .env 파일에 OPENAI_BASE_URL 설정 시 해당 엔드포인트로 연결

Closes #152