### PR TITLE
Fix: suppress empty Chromium startup window during benchmark runs

### DIFF
--- a/gaia/src/phase4/embedded_openclaw_runtime.py
+++ b/gaia/src/phase4/embedded_openclaw_runtime.py
@@ -225,6 +225,11 @@ def build_embedded_openclaw_config(
         "headless": browser_headless_enabled(),
         "defaultProfile": "openclaw",
         "cdpPortRangeStart": int(cdp_port),
+        # Suppress Chromium's default startup window (the empty chrome://newtab
+        # page that otherwise pops up alongside the controlled tab). The working
+        # tab is created on demand via CDP (Target.createTarget), so the browser
+        # process stays alive with no window until a session opens its own tab.
+        "extraArgs": ["--no-startup-window"],
         "profiles": {
             "openclaw": {
                 "cdpPort": int(cdp_port),

--- a/gaia/tests/unit/test_embedded_openclaw_runtime.py
+++ b/gaia/tests/unit/test_embedded_openclaw_runtime.py
@@ -20,6 +20,7 @@ def test_build_embedded_openclaw_config_defaults_to_local_unauthenticated_browse
     assert config["browser"]["defaultProfile"] == "openclaw"
     assert config["browser"]["profiles"]["openclaw"]["cdpPort"] == 18800
     assert config["browser"]["executablePath"].endswith("Google Chrome")
+    assert "--no-startup-window" in config["browser"]["extraArgs"]
 
 
 def test_embedded_browser_server_entrypoint_uses_event_loop_keepalive() -> None:


### PR DESCRIPTION
## 문제
벤치마크 실행 시, 작업용 탭과 별개로 **빈 Chromium 새 탭 창(`chrome://newtab/`)** 이 하나 더 떠서 사용자에게 보이는 현상이 있었음. (Issue #157)

원인은 openclaw가 `openclaw` 프로필로 Chromium을 띄울 때 시작 URL을 주지 않아, Chromium이 **기본 startup 창(새 탭 페이지)** 을 하나 여는 것이었음. headless가 꺼져 있어 이 창이 화면에 노출됨. 로그상 `new_page_count`에 잡히던 `chrome://newtab/` + `one-google-bar` 타겟이 바로 이 창이고, 나머지(moloco 광고 픽셀, youtube 임베드 등)는 사이트가 만든 백그라운드 타겟이라 창으로는 안 뜸.

## 변경
- `build_embedded_openclaw_config`의 `browser` 설정에 `extraArgs: ["--no-startup-window"]` 추가
  - 이 인자는 openclaw가 그대로 Chromium launch args로 전달 (`buildOpenClawChromeLaunchArgs` -> `resolved.extraArgs`)
  - 작업 탭은 세션 시작 시 CDP `Target.createTarget`(`openTab`)으로 생성되므로, startup 창만 사라지고 동작에는 영향 없음
- 단위 테스트에 `--no-startup-window` 플래그 존재 검증 추가

## 테스트
- `gaia/tests/unit/test_embedded_openclaw_runtime.py` 17 passed

## 영향 범위
- 빈 startup 창만 제거. 작업용 탭/탐색/성공률 동작 변화 없음.
- headless 모드에선 원래 창이 없으므로 무해.

🤖 Generated with [Claude Code](https://claude.com/claude-code)