### PR TITLE
Fix: auto-submit search-box fills via Enter (YES24 검색버튼 우회)

### DIFF
--- a/gaia/src/phase4/goal_driven/action_execution_runtime.py
+++ b/gaia/src/phase4/goal_driven/action_execution_runtime.py
@@ -551,6 +551,71 @@ def _fill_target_score(
     return score
 
 
+def _should_autosubmit_search_fill(
+    agent,
+    decision: ActionDecision,
+    element: Optional[DOMElement],
+) -> bool:
+    """Decide whether a successful fill should be auto-submitted via Enter.
+
+    Some search boxes (e.g. YES24's main search) bind their search *button* to a
+    JS handler that submits a stale internal query state — typically a rotating
+    "추천 검색어" promo — instead of the value we just typed, which redirects to an
+    unrelated event page. Pressing Enter triggers the native form submission,
+    which reads ``input.value`` (the text we actually filled), so it reliably
+    runs the intended query. We only do this for genuine search-box fills with a
+    search intent; everything else (login fields, multi-field forms, rich-text
+    bodies) is left untouched.
+    """
+    if element is None:
+        return False
+    role = _normalized_binding_text(agent, getattr(element, "role", ""))
+    role_ref_role = _normalized_binding_text(agent, getattr(element, "role_ref_role", ""))
+    field_type = _normalized_binding_text(agent, getattr(element, "type", ""))
+    element_blob = _fill_binding_blob(agent, element)
+    is_search_box = (
+        role == "searchbox"
+        or role_ref_role == "searchbox"
+        or field_type == "search"
+        or any(token in element_blob for token in ("검색", "search", "query"))
+    )
+    if not is_search_box:
+        return False
+    reasoning_blob = _normalized_binding_text(agent, getattr(decision, "reasoning", "") or "")
+    negative_search_context = any(
+        token in reasoning_blob
+        for token in (
+            "검색창에 잘못",
+            "검색창에만",
+            "검색 오버레이",
+            "검색창 오버레이",
+            "검색 포커스",
+            "성공 증거가 아니",
+            "search overlay",
+            "wrong search",
+        )
+    )
+    if negative_search_context:
+        return False
+    return any(
+        token in reasoning_blob
+        for token in (
+            "검색 입력",
+            "검색어",
+            "검색창에 입력",
+            "검색 필드",
+            "검색한다",
+            "검색하기",
+            "검색 결과",
+            "검색결과",
+            "search for",
+            "search query",
+            "type into search",
+            "enter search",
+        )
+    )
+
+
 def _find_fill_target_candidate(
     agent,
     decision: ActionDecision,
@@ -1826,6 +1891,22 @@ def execute_decision(
                 _remember_recent_signal_event()
                 _remember_auth_fill()
                 _remember_persistent_control_state()
+                if _should_autosubmit_search_fill(agent, decision, selected_element):
+                    fill_result = agent._last_exec_result
+                    try:
+                        agent._record_reason_code("search_fill_autosubmit")
+                    except Exception:
+                        pass
+                    submit_ok, submit_err = _execute_with_ref_recovery(
+                        "press", action_value="Enter"
+                    )
+                    if submit_ok:
+                        _remember_recent_signal_event()
+                        return True, submit_err
+                    # Enter submission was not actionable; restore the successful
+                    # fill result so the agent can still submit via the search
+                    # button on the next step (no regression vs. fill-only).
+                    agent._last_exec_result = fill_result
             return ok, err
 
         if decision.action == ActionType.TYPE:

--- a/gaia/src/phase4/goal_driven/action_execution_runtime.py
+++ b/gaia/src/phase4/goal_driven/action_execution_runtime.py
@@ -569,9 +569,9 @@ def _should_autosubmit_search_fill(
     """
     if element is None:
         return False
-    role = _normalized_binding_text(agent, getattr(element, "role", ""))
-    role_ref_role = _normalized_binding_text(agent, getattr(element, "role_ref_role", ""))
-    field_type = _normalized_binding_text(agent, getattr(element, "type", ""))
+    role = _normalized_binding_text(agent, element.role or "")
+    role_ref_role = _normalized_binding_text(agent, element.role_ref_role or "")
+    field_type = _normalized_binding_text(agent, element.type or "")
     element_blob = _fill_binding_blob(agent, element)
     is_search_box = (
         role == "searchbox"
@@ -597,6 +597,11 @@ def _should_autosubmit_search_fill(
     )
     if negative_search_context:
         return False
+    # NOTE: intentionally exclude "검색 결과"/"검색결과" — being *on* a results page
+    # is not an intent to submit a new query, and pairing it with a results/filter
+    # input (e.g. a min-price field whose container says "검색 결과") would wrongly
+    # auto-submit a multi-field filter. Keep tokens to genuine "enter a search
+    # query" intent only.
     return any(
         token in reasoning_blob
         for token in (
@@ -606,8 +611,6 @@ def _should_autosubmit_search_fill(
             "검색 필드",
             "검색한다",
             "검색하기",
-            "검색 결과",
-            "검색결과",
             "search for",
             "search query",
             "type into search",

--- a/gaia/tests/unit/test_action_execution_runtime.py
+++ b/gaia/tests/unit/test_action_execution_runtime.py
@@ -1791,3 +1791,21 @@ def test_autosubmit_search_fill_false_for_none_element() -> None:
     decision = _fill_decision("검색어를 입력합니다.")
 
     assert _should_autosubmit_search_fill(_TextAgent(), decision, None) is False
+
+
+def test_autosubmit_search_fill_false_for_results_page_filter_input() -> None:
+    # On a results/filter page the container text often contains "검색 결과", which
+    # makes the input look search-related; but typing a min-price filter value is
+    # NOT a request to submit a new query, so Enter must not be auto-pressed.
+    element = DOMElement(
+        id=6,
+        tag="input",
+        role="textbox",
+        ref_id="e50",
+        aria_label="최소 가격",
+        container_name="검색 결과",
+        context_text="검색 결과 1,200건 가격 필터 최소 가격 최대 가격",
+    )
+    decision = _fill_decision("검색 결과 페이지에서 최소 가격을 입력", value="50000")
+
+    assert _should_autosubmit_search_fill(_TextAgent(), decision, element) is False

--- a/gaia/tests/unit/test_action_execution_runtime.py
+++ b/gaia/tests/unit/test_action_execution_runtime.py
@@ -4,6 +4,7 @@ from gaia.src.phase4.goal_driven.action_execution_runtime import (
     _find_rebound_element,
     _find_visible_text_ref_candidate,
     _is_stale_like_timeout,
+    _should_autosubmit_search_fill,
     _visual_find_label_candidates,
     _visual_find_label_is_safe,
 )
@@ -339,9 +340,12 @@ def test_execute_decision_force_refreshes_fill_ref_recovery(monkeypatch) -> None
 
     assert ok is True
     assert err is None
-    assert calls == ["old-search-ref", "new-search-ref"]
+    # Trailing "new-search-ref" is the search-fill auto-submit (Enter) on the
+    # recovered search box.
+    assert calls == ["old-search-ref", "new-search-ref", "new-search-ref"]
     assert "ref_recovery" in agent.force_reasons
     assert True in agent.analyze_force_flags
+    assert "search_fill_autosubmit" in agent.reason_codes
 
 
 def test_execute_decision_repairs_non_fillable_search_target_before_fill(monkeypatch) -> None:
@@ -400,9 +404,11 @@ def test_execute_decision_repairs_non_fillable_search_target_before_fill(monkeyp
 
     assert ok is True
     assert err is None
-    assert calls == ["news-search-ref"]
+    # Second "news-search-ref" is the search-fill auto-submit (Enter).
+    assert calls == ["news-search-ref", "news-search-ref"]
     assert "fill_target_recovery" in agent.force_reasons
     assert any("fill 대상 재바인딩" in log for log in agent.logs)
+    assert "search_fill_autosubmit" in agent.reason_codes
 
 
 def test_execute_decision_keeps_rich_text_body_target_over_searchbox(monkeypatch) -> None:
@@ -1727,3 +1733,61 @@ def test_execute_decision_blocks_visual_coordinate_fallback_for_dangerous_label(
     assert calls == ["click"]
     assert "ref_recovery_failed_resnapshot" in agent.reason_codes
     assert "visual_coordinate_fallback_blocked" in agent.reason_codes
+
+
+class _TextAgent:
+    def _normalize_text(self, value: object) -> str:
+        return str(value or "").strip().lower()
+
+
+def _fill_decision(reasoning: str, value: str = "프로젝트 헤일메리") -> ActionDecision:
+    return ActionDecision(action=ActionType.FILL, value=value, reasoning=reasoning)
+
+
+def test_autosubmit_search_fill_true_for_searchbox_with_search_intent() -> None:
+    element = DOMElement(id=1, tag="input", role="searchbox", type="search", ref_id="e86")
+    decision = _fill_decision("검색창에 검색어를 입력합니다.")
+
+    assert _should_autosubmit_search_fill(_TextAgent(), decision, element) is True
+
+
+def test_autosubmit_search_fill_true_for_yes24_textbox_via_container() -> None:
+    # YES24 main search: role is plain "textbox" but the container/context carries 검색.
+    element = DOMElement(
+        id=2,
+        tag="input",
+        role="textbox",
+        ref_id="e86",
+        placeholder="수능 국어 기출 필수! <매3>",
+        container_name="검색",
+    )
+    decision = _fill_decision("상단 검색 입력창에 검색어를 입력해야 합니다.")
+
+    assert _should_autosubmit_search_fill(_TextAgent(), decision, element) is True
+
+
+def test_autosubmit_search_fill_false_for_non_search_input() -> None:
+    element = DOMElement(id=3, tag="input", role="textbox", ref_id="e10", aria_label="이메일")
+    decision = _fill_decision("로그인 이메일을 입력합니다.")
+
+    assert _should_autosubmit_search_fill(_TextAgent(), decision, element) is False
+
+
+def test_autosubmit_search_fill_false_without_search_intent() -> None:
+    element = DOMElement(id=4, tag="input", role="searchbox", type="search", ref_id="e86")
+    decision = _fill_decision("필드에 임의의 값을 채워 동작을 확인합니다.")
+
+    assert _should_autosubmit_search_fill(_TextAgent(), decision, element) is False
+
+
+def test_autosubmit_search_fill_false_on_negative_search_context() -> None:
+    element = DOMElement(id=5, tag="input", role="searchbox", type="search", ref_id="e86")
+    decision = _fill_decision("검색창에 잘못 입력되어 검색 오버레이를 정리하려고 검색어를 다시 넣습니다.")
+
+    assert _should_autosubmit_search_fill(_TextAgent(), decision, element) is False
+
+
+def test_autosubmit_search_fill_false_for_none_element() -> None:
+    decision = _fill_decision("검색어를 입력합니다.")
+
+    assert _should_autosubmit_search_fill(_TextAgent(), decision, None) is False


### PR DESCRIPTION
## 문제
YES24 검색 시나리오에서, 검색창에 검색어를 입력(`fill`)한 뒤 옆의 **"검색" 버튼을 클릭하면 검색 결과가 아니라 추천검색어 이벤트 페이지(`event.yes24.com/detail?eventNo=...`)로 리다이렉트**되는 현상.

### 원인
- YES24 메인 검색창은 JS로 관리되는 controlled input이고, "검색" 버튼의 onclick이 **내부 query state(회전하는 "추천 검색어" 프로모, 예: `수능 국어 기출 필수! <매3>`)** 를 제출함.
- `fill`(Playwright `locator.fill`)은 `input.value`와 `input` 이벤트만 세팅하고 keydown/keyup은 안 쏘기 때문에, JS 내부 state가 갱신되지 않아 버튼 클릭 시 stale 추천검색어로 검색 → 이벤트 페이지로 샘.
- 에이전트는 자가복구로 결국 성공했지만 2~5스텝을 헛돌았음.

## 해결
- **네이티브 폼 제출(Enter)은 `input.value`(= fill이 올바르게 넣은 검색어)를 읽으므로** 의도한 검색이 안정적으로 실행됨.
- `execute_decision`의 FILL 분기에서, fill 성공 후 대상이 **검색박스 + 검색 의도**일 때 같은 ref에서 **Enter를 자동 제출**.
- 게이팅: `_should_autosubmit_search_fill()` — role `searchbox`/type `search`/blob에 `검색·search·query` 포함 && reasoning에 검색 의도. 로그인/멀티필드/리치텍스트 본문 등은 제외. negative search context면 제외.
- **안전장치(회귀 방지):** Enter 제출이 actionable하지 않으면 fill 성공 결과를 복원 → 기존 동작(다음 스텝에 검색버튼 클릭)으로 폴백. 순수 추가 동작.
- 관측용 reason code `search_fill_autosubmit` 기록.

## 테스트
- `_should_autosubmit_search_fill` 신규 유닛 테스트 6종 추가
- 기존 ref-recovery 테스트 2종은 자동 제출 Enter 반영해 기대값 갱신
- `gaia/tests/unit` 관련 스위트 209 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)